### PR TITLE
 🔀 :: [#47] 커스텀 네비게이션 뒤로가기 버튼 표시 로직 수정

### DIFF
--- a/Projects/Feature/Sources/Base/BaseViewController.swift
+++ b/Projects/Feature/Sources/Base/BaseViewController.swift
@@ -33,7 +33,9 @@ public class BaseViewController: UIViewController {
 
         navigationController?.navigationBar.isHidden = true
         setupKeyboardEvent()
+        
         setupCustomNavigation()
+
         configureUI()
         addView()
         setLayout()
@@ -44,17 +46,28 @@ public class BaseViewController: UIViewController {
 
         navigationController?.navigationBar.isHidden = true
 
-     
-        if parent != nil {
-            customNavView.isHidden = true
-        }
-       
-        else if let nav = navigationController,
-                nav.viewControllers.contains(self),
-                nav.viewControllers.first !== self {
-            customNavView.isHidden = false
-        }
-        else {
+        if let nav = navigationController {
+
+        
+            if self is MainViewController {
+                customNavView.isHidden = true
+            }
+
+            
+            else if parent is MainViewController {
+                customNavView.isHidden = true
+            }
+
+    
+            else if nav.viewControllers.count > 1 {
+                customNavView.isHidden = false
+            }
+
+            else {
+                customNavView.isHidden = true
+            }
+
+        } else {
             customNavView.isHidden = true
         }
 

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -125,23 +125,10 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
     // MARK: - Selectors
     @objc func settingButtonTapped() {
         settingButton.isUserInteractionEnabled = false
-
-        let vc = UserProfileViewController()
-        self.profileVC = vc
-
-        addChild(vc)
-        view.addSubview(vc.view)
-
-        vc.view.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(tabBar.snp.top)
-        }
-
-        vc.didMove(toParent: self)
+        showProfileOverlay()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            guard let self = self else { return }
-            self.settingButton.isUserInteractionEnabled = true
+            self?.settingButton.isUserInteractionEnabled = true
         }
     }
 
@@ -162,18 +149,41 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         }
     }
 
-    func selectHomeTab() {
-        selectedTab = .home
+    private func showProfileOverlay() {
+        if profileVC != nil { return }
 
-        if let profile = profileVC {
-            profile.willMove(toParent: nil)
-            profile.view.removeFromSuperview()
-            profile.removeFromParent()
-            profileVC = nil
+        let vc = UserProfileViewController()
+        profileVC = vc
+
+        addChild(vc)
+        view.addSubview(vc.view)
+
+        vc.view.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(tabBar.snp.top)
         }
+
+        vc.didMove(toParent: self)
+        qrButton.isHidden = true
+        view.bringSubviewToFront(tabBar)
+    }
+
+    private func hideProfileOverlay() {
+        guard let profile = profileVC else { return }
+
+        profile.willMove(toParent: nil)
+        profile.view.removeFromSuperview()
+        profile.removeFromParent()
+        profileVC = nil
+    }
+
+    func selectHomeTab() {
+        hideProfileOverlay()
+        selectedTab = .home
     }
 
     func selectMapTab() {
+        hideProfileOverlay()
         selectedTab = .map
     }
 
@@ -183,9 +193,16 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         scrollView.isHidden = !isHome
         mapContainerView.isHidden = isHome
         qrButton.isHidden = !isHome
+        if profileVC != nil {
+            qrButton.isHidden = true
+        }
 
         view.bringSubviewToFront(tabBar)
         view.bringSubviewToFront(qrButton)
+        if let profileView = profileVC?.view {
+            view.bringSubviewToFront(profileView)
+            view.bringSubviewToFront(tabBar)
+        }
     }
 
     private func bindTabBar() {
@@ -196,30 +213,12 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
             case .home:
                 self.tabBar.selectedTab = .home
                 self.selectHomeTab()
-                if let profile = self.profileVC {
-                    profile.willMove(toParent: nil)
-                    profile.view.removeFromSuperview()
-                    profile.removeFromParent()
-                    self.profileVC = nil
-                }
             case .map:
                 self.tabBar.selectedTab = .map
                 self.selectMapTab()
             case .profile:
-                if self.profileVC == nil {
-                    let vc = UserProfileViewController()
-                    self.profileVC = vc
-
-                    self.addChild(vc)
-                    self.view.addSubview(vc.view)
-
-                    vc.view.snp.makeConstraints {
-                        $0.top.leading.trailing.equalToSuperview()
-                        $0.bottom.equalTo(self.tabBar.snp.top)
-                    }
-
-                    vc.didMove(toParent: self)
-                }
+                self.tabBar.selectedTab = .profile
+                self.showProfileOverlay()
             }
         }
     }

--- a/Projects/Feature/Sources/Scene/Profile/Controller/ChangPassword/ProfileChangRePasswordViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/ChangPassword/ProfileChangRePasswordViewController.swift
@@ -45,8 +45,6 @@ public class ProfileChangRePasswordViewController: BaseViewController, UIImagePi
         $0.addTarget(self, action: #selector(doneButtonTapped), for: .touchUpInside)
     }
     
-    private var doneButtonBottomConstraint: Constraint?
-    private var textFieldBottomConstraint: Constraint?
     
     @objc func doneButtonTapped() {
         let defaults = UserDefaults.standard
@@ -78,6 +76,10 @@ public class ProfileChangRePasswordViewController: BaseViewController, UIImagePi
         }
     }
     
+    @objc private func backButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -88,7 +90,17 @@ public class ProfileChangRePasswordViewController: BaseViewController, UIImagePi
     }
     
     public override func configNavigation() {
-        navigationController?.navigationBar.tintColor = .color.admin.color
+        super.configNavigation()
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationItem.title = "비밀번호 재설정"
+
+        let backButton = UIBarButtonItem(
+            image: UIImage(systemName: "chevron.left"),
+            style: .plain,
+            target: self,
+            action: #selector(backButtonTapped)
+        )
+        navigationItem.leftBarButtonItem = backButton
     }
     
     public override func addView() {
@@ -109,7 +121,7 @@ public class ProfileChangRePasswordViewController: BaseViewController, UIImagePi
             $0.top.equalToSuperview().inset(100)
             $0.leading.equalToSuperview().inset(bounds.width * 0.05)
         }
-        
+
         passwordTextField.snp.makeConstraints {
             $0.height.equalTo(64)
             $0.width.equalTo(335)
@@ -117,45 +129,50 @@ public class ProfileChangRePasswordViewController: BaseViewController, UIImagePi
             $0.leading.equalToSuperview().inset(bounds.width * 0.05)
             $0.trailing.equalToSuperview().inset(bounds.width * 0.05)
         }
-        
+
         passwordErrorLabel.snp.makeConstraints {
             $0.height.equalTo(48)
             $0.top.equalTo(passwordTextField.snp.bottom)
             $0.leading.equalTo(bounds.width * 0.07)
         }
-        
+
         doneButton.snp.makeConstraints {
-            doneButtonBottomConstraint = $0.bottom.equalToSuperview().inset(bounds.height * 0.19).constraint
             $0.height.equalTo(48)
-            $0.width.equalTo(335)
-            $0.leading.equalToSuperview().inset(bounds.width * 0.05)
-            $0.trailing.equalToSuperview().inset(bounds.width * 0.05)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide).offset(-24)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-24)
         }
     }
     
     public override func keyboardWillShow(_ notification: Notification) {
-        guard let userInfo = notification.userInfo,
-              let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
-            return
+        guard
+            let userInfo = notification.userInfo,
+            let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+            let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
+
+        let keyboardHeight = keyboardFrame.height - view.safeAreaInsets.bottom
+
+        doneButton.snp.updateConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-(keyboardHeight + 24))
         }
-        
-        let keyboardHeight = keyboardFrame.height
-        
-        UIView.animate(withDuration: 0.3) { [weak self] in
-            guard let self = self else { return }
-            self.doneButtonBottomConstraint?.update(inset: keyboardHeight + 13)
-            self.textFieldBottomConstraint?.update(inset: keyboardHeight + (self.bounds.height * 0.2))
-            
+
+        UIView.animate(withDuration: duration) {
             self.view.layoutIfNeeded()
         }
     }
-    
+
     public override func keyboardWillHide(_ notification: Notification) {
-        UIView.animate(withDuration: 0.3) { [weak self] in
-            guard let self = self else { return }
-            self.doneButtonBottomConstraint?.update(inset: self.bounds.height * 0.19)
-            self.textFieldBottomConstraint?.update(inset: self.bounds.height * 0.45)
-            
+        guard
+            let userInfo = notification.userInfo,
+            let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
+
+        doneButton.snp.updateConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-24)
+        }
+
+        UIView.animate(withDuration: duration) {
             self.view.layoutIfNeeded()
         }
     }
@@ -172,5 +189,4 @@ extension ProfileChangRePasswordViewController: UITextFieldDelegate {
         return true
     }
 }
-
 


### PR DESCRIPTION
# 🍎 개요
BaseViewController에서 커스텀 네비게이션 뒤로가기 버튼 표시 로직을 수정하여
Tab 기반 화면과 overlay 화면에서는 뒤로가기 버튼이 표시되지 않도록 하고,
push 방식으로 이동한 화면에서는 정상적으로 표시되도록 수정

# 📦 작업 내용
- BaseViewController의 뒤로가기 버튼 표시 조건 로직 수정
- MainViewController에서 뒤로가기 버튼이 표시되던 문제 해결
- MainViewController 위에 overlay로 표시되는 UserProfileViewController에서 뒤로가기 버튼이 표시되던 문제 해결
- Navigation push로 이동한 화면(QR, 비밀번호 재설정 등)에서 뒤로가기 버튼 정상 표시
- 커스텀 네비게이션 생성 및 표시 조건 정리