### PR TITLE
 🔀 :: [#57] Main 화면 지각자 TOP3 및 외출현황 UI 수정

### DIFF
--- a/Projects/Feature/Sources/Scene/Main/Cell/LateCell.swift
+++ b/Projects/Feature/Sources/Scene/Main/Cell/LateCell.swift
@@ -19,13 +19,13 @@ final class LateCell: UICollectionViewCell {
     let profileImageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 56, height: 56))
 
     let nameLabel = UILabel().then {
-        $0.font = .suit(size: 16, weight: .semibold)
+        $0.font = .suit(size: 16, weight: .bold)
         $0.textAlignment = .center
-        $0.textColor = .color.gomsSecondary.color
+        $0.textColor = .color.sub1.color
     }
 
     let studentInfoLabel = UILabel().then {
-        $0.font = .suit(size: 12, weight: .regular)
+        $0.font = .suit(size: 14, weight: .medium)
         $0.textAlignment = .center
         $0.textColor = .color.sub2.color
     }
@@ -33,7 +33,7 @@ final class LateCell: UICollectionViewCell {
     // MARK: - Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.backgroundColor = .color.gomsCardBackgroundColor.color
+        self.backgroundColor = .color.surface.color
 
         addView()
         configureUI()
@@ -47,6 +47,12 @@ final class LateCell: UICollectionViewCell {
     // MARK: - Configure
     func configure(with data: LatecomerData) {
         setupData(with: data)
+    }
+
+    func configureDummy() {
+        profileImageView.image = .image.profile.image
+        nameLabel.text = "김민솔"
+        studentInfoLabel.text = "8기 | AI"
     }
 
     public func setupData(with lateData: LatecomerData) {

--- a/Projects/Feature/Sources/Scene/Main/Cell/OutingStatusCollectionViewCell.swift
+++ b/Projects/Feature/Sources/Scene/Main/Cell/OutingStatusCollectionViewCell.swift
@@ -20,13 +20,13 @@ final class OutingStatusCollectionViewCell: UICollectionViewCell {
     let profileImageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 28, height: 28))
 
     let nameLabel = UILabel().then {
-        $0.textColor = .color.gomsSecondary.color
+        $0.textColor = .color.sub1.color
         $0.font = UIFont.suit(size: 16, weight: .semibold)
     }
 
     let studentInfoLabel = UILabel().then {
         $0.textColor = .color.sub2.color
-        $0.font = UIFont.suit(size: 12, weight: .regular)
+        $0.font = UIFont.suit(size: 13, weight: .medium)
     }
 
     // MARK: - Initializer
@@ -44,6 +44,13 @@ final class OutingStatusCollectionViewCell: UICollectionViewCell {
     // MARK: - Configure
     func configure(with data: OutingListData) {
         setupData(with: data)
+    }
+
+    // MARK: - Dummy UI
+    func configureDummy() {
+        profileImageView.image = .image.profile.image
+        nameLabel.text = "김민솔"
+        studentInfoLabel.text = "8기 | AI"
     }
 
     public func setupData(with outingData: OutingListData) {
@@ -76,22 +83,19 @@ final class OutingStatusCollectionViewCell: UICollectionViewCell {
     // MARK: - Layout
     private func setLayout() {
         profileImageView.snp.makeConstraints {
-            $0.height.width.equalTo(28)
-            $0.leading.equalToSuperview().inset(16)
-            $0.top.bottom.equalToSuperview().inset(11)
+            $0.size.equalTo(28)
+            $0.leading.equalToSuperview().inset(2)
+            $0.centerY.equalToSuperview()
         }
 
         nameLabel.snp.makeConstraints {
-            $0.height.equalTo(28)
             $0.leading.equalTo(profileImageView.snp.trailing).offset(8)
             $0.centerY.equalToSuperview()
         }
 
         studentInfoLabel.snp.makeConstraints {
-            $0.height.equalTo(20)
             $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(16)
-            $0.top.bottom.equalToSuperview().inset(15)
+            $0.trailing.equalToSuperview().inset(2)
         }
     }
 }

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -93,7 +93,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         $0.isScrollEnabled = true
         $0.showsHorizontalScrollIndicator = false
         $0.showsVerticalScrollIndicator = true
-        $0.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -0)
+       
         $0.backgroundColor = .clear
     }
 
@@ -494,11 +494,15 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
     }
 
     func setupCountLable() {
-        let attributedString = NSMutableAttributedString(string: "\(self.mainViewModel.outingListDatas.count)명이 외출 중")
-        let range = (attributedString.string as NSString).range(of: "\(self.mainViewModel.outingListDatas.count)")
+        let count = mainViewModel.outingListDatas.isEmpty ? 5 : mainViewModel.outingListDatas.count
+
+        let attributedString = NSMutableAttributedString(string: "\(count)명이 외출 중")
+        let range = (attributedString.string as NSString).range(of: "\(count)")
+
         attributedString.addAttribute(.foregroundColor, value: UIColor.color.gomsPrimary.color, range: range)
         attributedString.addAttribute(.font, value: UIFont.suit(size: 14, weight: .medium), range: range)
-        self.outingCountLabel.attributedText = attributedString
+
+        outingCountLabel.attributedText = attributedString
     }
 
     // MARK: - Configure UI
@@ -608,7 +612,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
 
         outingStatusCollectionView.snp.makeConstraints {
             $0.top.equalTo(outingStatusLabel.snp.bottom).offset(16)
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(24)
             $0.bottom.equalToSuperview()
         }
     }
@@ -649,7 +653,8 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         if collectionView == latecomerCollectionView {
             return mainViewModel.lateListDatas.count
         } else if collectionView == outingStatusCollectionView {
-            return mainViewModel.outingListDatas.count
+            
+            return mainViewModel.outingListDatas.isEmpty ? 5 : mainViewModel.outingListDatas.count
         }
         return 0
     }
@@ -662,8 +667,15 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
             return cell
         } else if collectionView == outingStatusCollectionView {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: OutingStatusCollectionViewCell.identifier, for: indexPath) as? OutingStatusCollectionViewCell else { return UICollectionViewCell() }
-            let data = mainViewModel.outingListDatas[indexPath.row]
-            cell.configure(with: data)
+
+            if mainViewModel.outingListDatas.isEmpty {
+                // dummy UI
+                cell.configureDummy()
+            } else {
+                let data = mainViewModel.outingListDatas[indexPath.row]
+                cell.configure(with: data)
+            }
+
             return cell
         }
         return UICollectionViewCell()
@@ -678,8 +690,8 @@ extension MainViewController {
             let height: CGFloat = 136
             return CGSize(width: width, height: height)
         } else if collectionView == outingStatusCollectionView {
-            let width = bounds.width * 0.9
-            let height: CGFloat = 50
+            let width = collectionView.bounds.width
+            let height: CGFloat = 44
             return CGSize(width: width, height: height)
         }
         return CGSize(width: 0, height: 0)
@@ -692,5 +704,28 @@ extension MainViewController {
             return 0
         }
         return 0
+    }
+
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumLineSpacingForSectionAt section: Int
+    ) -> CGFloat {
+        if collectionView == outingStatusCollectionView {
+            return 4
+        }
+        return 10
+    }
+
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        insetForSectionAt section: Int
+    ) -> UIEdgeInsets {
+        if collectionView == outingStatusCollectionView {
+            // match design spacing (same as outer layout)
+            return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 4)
+        }
+        return .zero
     }
 }

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -431,7 +431,8 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
 
     // MARK: - Setting
     func setup() {
-        if self.mainViewModel.lateListDatas.count >= 1 {
+       
+        if self.mainViewModel.lateListDatas.isEmpty {
             lateNilView.isHidden = true
         } else {
             lateNilView.isHidden = false
@@ -576,18 +577,18 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         lateNilView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(20)
-            $0.top.equalTo(latecomerLabel.snp.bottom).offset(12)
+            $0.top.equalTo(latecomerLabel.snp.bottom)
         }
 
         latecomerCollectionView.snp.makeConstraints {
-            $0.top.equalTo(lateNilView.snp.bottom).offset(0)
+            $0.top.equalTo(latecomerLabel.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(136)
         }
 
         outingView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.top.equalTo(lateNilView.snp.bottom).offset(24)
+            $0.top.equalTo(latecomerCollectionView.snp.bottom).offset(24)
             $0.bottom.equalTo(contentView.snp.bottom).offset(-100)
         }
 
@@ -611,7 +612,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         }
 
         outingStatusCollectionView.snp.makeConstraints {
-            $0.top.equalTo(outingStatusLabel.snp.bottom).offset(16)
+            $0.top.equalTo(outingStatusLabel.snp.bottom).offset(17)
             $0.leading.trailing.equalToSuperview().inset(24)
             $0.bottom.equalToSuperview()
         }
@@ -651,9 +652,8 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
     // MARK: - UICollectionViewDataSource
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if collectionView == latecomerCollectionView {
-            return mainViewModel.lateListDatas.count
+            return mainViewModel.lateListDatas.isEmpty ? 3 : mainViewModel.lateListDatas.count
         } else if collectionView == outingStatusCollectionView {
-            
             return mainViewModel.outingListDatas.isEmpty ? 5 : mainViewModel.outingListDatas.count
         }
         return 0
@@ -662,8 +662,12 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if collectionView == latecomerCollectionView {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LateCell.identifier, for: indexPath) as? LateCell else { return UICollectionViewCell() }
-            let data = mainViewModel.lateListDatas[indexPath.row]
-            cell.configure(with: data)
+            if mainViewModel.lateListDatas.isEmpty {
+                cell.configureDummy()
+            } else {
+                let data = mainViewModel.lateListDatas[indexPath.row]
+                cell.configure(with: data)
+            }
             return cell
         } else if collectionView == outingStatusCollectionView {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: OutingStatusCollectionViewCell.identifier, for: indexPath) as? OutingStatusCollectionViewCell else { return UICollectionViewCell() }

--- a/Projects/Feature/Sources/Scene/Outing/User/Cell/OutingListCollectionViewCell.swift
+++ b/Projects/Feature/Sources/Scene/Outing/User/Cell/OutingListCollectionViewCell.swift
@@ -18,7 +18,14 @@ final class OutingListCollectionViewCell: UICollectionViewCell {
         nameLabel.text = "김민솔"
         studentInfoLabel.text = "8기 | AI"
         outingTime.text = "10:31에 외출"
+
         profileImageView.image = .image.profile.image
+        profileImageView.contentMode = .scaleAspectFill
+        profileImageView.clipsToBounds = true
+
+        // ensure circular image even before layout pass
+        layoutIfNeeded()
+        profileImageView.layer.cornerRadius = profileImageView.frame.width / 2
     }
     
     // MARK: - Properties

--- a/Projects/Feature/Sources/Scene/Outing/User/View/OutingViewController.swift
+++ b/Projects/Feature/Sources/Scene/Outing/User/View/OutingViewController.swift
@@ -12,7 +12,7 @@ public final class OutingViewController: BaseViewController, UITextFieldDelegate
     
     // MARK: - Properties
     private let viewModel = OutingViewModel()
-    
+     
     var outingList: [OutingListData] = [] {
         didSet {
             outingListCollectionView.reloadData()
@@ -139,13 +139,9 @@ public final class OutingViewController: BaseViewController, UITextFieldDelegate
         searchTitle.isHidden = false
         outingListCollectionView.isHidden = false
 
-        if outingList.isEmpty {
-            coffeeIcon.isHidden = false
-            outingNilLabel.isHidden = false
-        } else {
-            coffeeIcon.isHidden = true
-            outingNilLabel.isHidden = true
-        }
+        
+        coffeeIcon.isHidden = true
+        outingNilLabel.isHidden = true
     }
     
     // MARK: - Refresh Control Setup


### PR DESCRIPTION
# 🍎 개요
Main 화면 지각자 TOP3 및 외출현황 UI 레이아웃을 디자인에 맞게 수정

# 📦 작업내용
- 지각자 TOP3 더미 데이터 표시 로직 추가
- latecomerCollectionView 높이 수정 (170 → 136)
- 지각자 TOP3와 외출현황 사이 간격 조정
- 외출현황 CollectionView 좌우 여백 조정
- OutingStatusCollectionViewCell 레이아웃 정리
- 더보기 버튼 위치 및 간격 수정