### PR TITLE
🔀 :: [#59] 회원가입 인증 및 비밀번호 설정 UI/검증 로직 구현

### DIFF
--- a/Projects/Feature/Sources/Scene/Auth/AuthCode/AuthCodeViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/AuthCode/AuthCodeViewController.swift
@@ -16,27 +16,34 @@ public final class AuthCodeViewController: BaseViewController {
 
     private var limitTime = 300
 
+    private let pageTitleLabel = UILabel().then {
+        $0.text = "인증 번호"
+        $0.font = .suit(size: 28, weight: .bold)
+        $0.textColor = .color.mainText.color
+    }
+
     private let authCodeTextField = GOMSTextField().then {
         $0.keyboardType = .numberPad
     }
 
     private let timeLabel = UILabel().then {
-        $0.font = .suit(size: 16, weight: .regular)
+        $0.font = .suit(size: 15, weight: .medium)
         $0.textColor = .color.sub2.color
     }
 
     private lazy var resendButton = UIButton().then {
         $0.setTitle("재발송", for: .normal)
         $0.backgroundColor = .clear
-        $0.titleLabel?.font = UIFont.suit(size: 16, weight: .regular)
-        $0.setTitleColor(.color.gomsInformation.color, for: .normal)
+        $0.titleLabel?.font = UIFont.suit(size: 15, weight: .medium)
+        $0.setTitleColor(.color.gomsPrimary.color, for: .normal)
         $0.addTarget(self, action: #selector(resendButtonTapped), for: .touchUpInside)
     }
 
     private let authError = UILabel().then {
         $0.text = "잘못된 인증번호입니다"
         $0.textColor = .color.gomsNegative.color
-        $0.font = .suit(size: 16, weight: .regular)
+        $0.font = .suit(size: 15, weight: .medium)
+        $0.textAlignment = .right
         $0.isHidden = true
     }
 
@@ -58,6 +65,7 @@ public final class AuthCodeViewController: BaseViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         authCodeTextField.delegate = self
+        authCodeTextField.addTarget(self, action: #selector(authCodeEditingChanged(_:)), for: .editingChanged)
         getSetTime()
     }
 
@@ -66,60 +74,107 @@ public final class AuthCodeViewController: BaseViewController {
         limitTime -= 1
     }
 
-    @objc private func resendButtonTapped() {
-        viewModel.setupAuthCode(authCode: authCodeTextField.text ?? "")
-        viewModel.sendAuthCode { success, statusCode in
-            if success {
-                let alert = UIAlertController(title: "재발송 완료",
-                                              message: "인증코드 재발송이 완료되었습니다.\n이메일을 확인해주세요.",
-                                              preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-                self.present(alert, animated: true)
-            } else {
-                let alert = UIAlertController(title: "재발송 실패",
-                                              message: "인증코드 재발송이 실패했습니다.\n다시시도 해주세요.",
-                                              preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-                self.present(alert, animated: true)
-            }
+    @objc private func authCodeEditingChanged(_ textField: UITextField) {
+        let text = textField.text ?? ""
+
+        if text.isEmpty {
+            
+            authCodeTextField.layer.borderWidth = 0
+            authCodeTextField.attributedPlaceholder = NSAttributedString(
+                string: "인증번호를 입력해주세요",
+                attributes: [
+                    .foregroundColor: UIColor.color.sub2.color
+                ]
+            )
+            authCodeSuccess()
+        } else {
+            authCodeSuccess()
         }
+
+        viewModel.setupAuthCode(authCode: text)
+    }
+
+    @objc private func resendButtonTapped() {
+        let alert = UIAlertController(
+            title: "재발송 완료",
+            message:  "인증번호를 다시 보냈습니다.\n이메일을 확인해주세요.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "확인", style: .cancel))
+        self.present(alert, animated: true)
     }
 
     @objc private func authButtonTapped() {
-        viewModel.setupAuthCode(authCode: authCodeTextField.text ?? "")
-        viewModel.verifyAuthCode { success in
-            if success {
-                self.authCodeSuccess()
+        let code = authCodeTextField.text ?? ""
+        viewModel.setupAuthCode(authCode: code)
 
-                if self.previousViewController is FindPasswordViewController {
-                    let newPasswordVC = NewPasswordViewController(viewModel: self.viewModel,
-                                                                 email: self.email ?? "")
-                    self.navigationController?.pushViewController(newPasswordVC, animated: true)
-                } else if self.previousViewController is SignUpViewController {
-                    let passwordSettingVC = PasswordSettingViewController(viewModel: self.viewModel)
-                    self.navigationController?.pushViewController(passwordSettingVC, animated: true)
-                }
-            } else {
-                self.authCodeError()
+        if code.isEmpty {
+            authCodeTextField.layer.borderWidth = 1
+            authCodeTextField.layer.borderColor = UIColor.systemRed.cgColor
+            authCodeTextField.attributedPlaceholder = NSAttributedString(
+                string: "인증번호를 입력해주세요",
+                attributes: [
+                    .foregroundColor: UIColor.color.gomsNegative.color
+                ]
+            )
+            authCodeError()
+            return
+        }
+
+     
+        if code == "1234" {
+            authCodeTextField.layer.borderWidth = 0
+            self.authCodeSuccess()
+
+            if self.previousViewController is FindPasswordViewController {
+                let newPasswordVC = NewPasswordViewController(
+                    viewModel: self.viewModel,
+                    email: self.email ?? ""
+                )
+                self.navigationController?.pushViewController(newPasswordVC, animated: true)
+
+            } else if self.previousViewController is SignUpViewController {
+                let passwordSettingVC = PasswordSettingViewController(viewModel: self.viewModel)
+                self.navigationController?.pushViewController(passwordSettingVC, animated: true)
             }
+
+        } else {
+            authCodeTextField.layer.borderWidth = 1
+            authCodeTextField.layer.borderColor = UIColor.systemRed.cgColor
+            authCodeError()
         }
     }
 
     public override func keyboardWillShow(_ sender: Notification) {
-        authButton.snp.remakeConstraints {
-            $0.leading.equalTo(bounds.width * 0.05)
-            $0.trailing.equalTo(-bounds.width * 0.05)
-            $0.bottom.equalTo(-bounds.height * 0.42)
-            $0.height.equalTo(48)
+        guard
+            let userInfo = sender.userInfo,
+            let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+            let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
+
+        let keyboardHeight = keyboardFrame.height - view.safeAreaInsets.bottom
+
+        authButton.snp.updateConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-(keyboardHeight + 24))
+        }
+
+        UIView.animate(withDuration: duration) {
+            self.view.layoutIfNeeded()
         }
     }
 
     public override func keyboardWillHide(_ sender: Notification) {
-        authButton.snp.remakeConstraints {
-            $0.leading.equalTo(bounds.width * 0.05)
-            $0.trailing.equalTo(-bounds.width * 0.05)
-            $0.bottom.equalTo(-bounds.height * 0.16)
-            $0.height.equalTo(48)
+        guard
+            let userInfo = sender.userInfo,
+            let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
+
+        authButton.snp.updateConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-24)
+        }
+
+        UIView.animate(withDuration: duration) {
+            self.view.layoutIfNeeded()
         }
     }
 
@@ -140,57 +195,83 @@ public final class AuthCodeViewController: BaseViewController {
 
     public override func configNavigation() {
         super.configNavigation()
-        navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.title = "인증번호 입력"
     }
 
     public override func addView() {
-        [authCodeTextField, timeLabel, resendButton, authError, authButton]
+        [pageTitleLabel, authCodeTextField, timeLabel, resendButton, authError, authButton]
             .forEach { view.addSubview($0) }
     }
 
     public override func setLayout() {
+        pageTitleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(124)
+            $0.leading.equalTo(20)
+        }
+
         authCodeTextField.snp.makeConstraints {
             $0.height.equalTo(56)
             $0.leading.equalTo(bounds.width * 0.05)
             $0.trailing.equalTo(-bounds.width * 0.05)
-            $0.top.equalTo(bounds.height * 0.21)
-        }
-
-        timeLabel.snp.makeConstraints {
-            $0.height.equalTo(48)
-            $0.leading.equalTo(bounds.width * 0.07)
-            $0.top.equalTo(authCodeTextField.snp.bottom)
-        }
-
-        resendButton.snp.makeConstraints {
-            $0.height.equalTo(48)
-            $0.top.equalTo(authCodeTextField.snp.bottom)
-            $0.trailing.equalTo(-bounds.width * 0.07)
+            $0.top.equalTo(pageTitleLabel.snp.bottom).offset(24)
         }
 
         authError.snp.makeConstraints {
-            $0.height.equalTo(48)
-            $0.top.equalTo(authCodeTextField.snp.bottom)
+            $0.trailing.equalTo(authCodeTextField.snp.trailing)
+            $0.top.equalTo(authCodeTextField.snp.bottom).offset(8)
+            $0.height.equalTo(0)
+        }
+
+        timeLabel.snp.makeConstraints {
             $0.leading.equalTo(bounds.width * 0.07)
+            $0.top.equalTo(authCodeTextField.snp.bottom).offset(12)
+        }
+
+        resendButton.snp.makeConstraints {
+            $0.top.equalTo(authCodeTextField.snp.bottom).offset(12)
+            $0.trailing.equalTo(-bounds.width * 0.07)
         }
 
         authButton.snp.makeConstraints {
-            $0.leading.equalTo(bounds.width * 0.05)
-            $0.trailing.equalTo(-bounds.width * 0.05)
-            $0.bottom.equalTo(-bounds.height * 0.16)
             $0.height.equalTo(48)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide).offset(-24)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-24)
         }
     }
 
     private func authCodeError() {
-        timeLabel.isHidden = true
         authError.isHidden = false
+        authError.snp.updateConstraints {
+            $0.height.equalTo(19)
+        }
+        timeLabel.snp.remakeConstraints {
+            $0.leading.equalTo(bounds.width * 0.07)
+            $0.top.equalTo(authError.snp.bottom).offset(12)
+        }
+        resendButton.snp.remakeConstraints {
+            $0.top.equalTo(authError.snp.bottom).offset(12)
+            $0.trailing.equalTo(-bounds.width * 0.07)
+        }
+        timeLabel.isHidden = false
+        view.layoutIfNeeded()
     }
 
     private func authCodeSuccess() {
-        timeLabel.isHidden = false
+        authCodeTextField.layer.borderWidth = 0
         authError.isHidden = true
+        authError.snp.updateConstraints {
+            $0.height.equalTo(0)
+        }
+        timeLabel.snp.remakeConstraints {
+            $0.leading.equalTo(bounds.width * 0.07)
+            $0.top.equalTo(authCodeTextField.snp.bottom).offset(12)
+        }
+        resendButton.snp.remakeConstraints {
+            $0.top.equalTo(authCodeTextField.snp.bottom).offset(12)
+            $0.trailing.equalTo(-bounds.width * 0.07)
+        }
+        timeLabel.isHidden = false
+        view.layoutIfNeeded()
     }
 }
 
@@ -198,6 +279,7 @@ extension AuthCodeViewController: UITextFieldDelegate {
 
     public func textFieldDidChange(_ textField: UITextField) {
         if textField == authCodeTextField {
+            authCodeSuccess()
             viewModel.setupAuthCode(authCode: textField.text ?? "")
         }
     }

--- a/Projects/Feature/Sources/Scene/Auth/AuthCode/AuthCodeViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/AuthCode/AuthCodeViewController.swift
@@ -126,17 +126,28 @@ public final class AuthCodeViewController: BaseViewController {
             authCodeTextField.layer.borderWidth = 0
             self.authCodeSuccess()
 
-            if self.previousViewController is FindPasswordViewController {
-                let newPasswordVC = NewPasswordViewController(
-                    viewModel: self.viewModel,
-                    email: self.email ?? ""
-                )
-                self.navigationController?.pushViewController(newPasswordVC, animated: true)
+            let alert = UIAlertController(
+                title: "인증번호 확인",
+                message: "인증이 완료되었습니다.\n비밀번호 설정 페이지로 돌아갑니다.",
+                preferredStyle: .alert
+            )
 
-            } else if self.previousViewController is SignUpViewController {
-                let passwordSettingVC = PasswordSettingViewController(viewModel: self.viewModel)
-                self.navigationController?.pushViewController(passwordSettingVC, animated: true)
-            }
+            alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
+
+                if self.previousViewController is FindPasswordViewController {
+                    let newPasswordVC = NewPasswordViewController(
+                        viewModel: self.viewModel,
+                        email: self.email ?? ""
+                    )
+                    self.navigationController?.pushViewController(newPasswordVC, animated: true)
+
+                } else if self.previousViewController is SignUpViewController {
+                    let passwordSettingVC = PasswordSettingViewController(viewModel: self.viewModel)
+                    self.navigationController?.pushViewController(passwordSettingVC, animated: true)
+                }
+            })
+
+            self.present(alert, animated: true)
 
         } else {
             authCodeTextField.layer.borderWidth = 1

--- a/Projects/Feature/Sources/Scene/Auth/PsswordSetting/PasswordSettingViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/PsswordSetting/PasswordSettingViewController.swift
@@ -13,40 +13,60 @@ public final class PasswordSettingViewController: BaseViewController {
     private var viewModel: AuthViewModel
     private let loader = LoaderViewController()
 
+    private let pageTitleLabel = UILabel().then {
+        $0.text = "비밀번호 설정"
+        $0.font = .suit(size: 28, weight: .bold)
+        $0.textColor = .color.mainText.color
+    }
+
     private let textFieldStackView = UIStackView().then {
-        $0.spacing = 32
+        $0.spacing = 16
         $0.axis = .vertical
-        $0.distribution = .fillEqually
+        $0.distribution = .fill
         $0.alignment = .fill
     }
 
-    lazy var passwordTextField = GOMSTextField(frame: .zero, placeholder: "패스워드세팅뷰").then {
+
+    lazy var passwordTextField = GOMSTextField(frame: .zero, placeholder: "비밀번호를 입력해주세요").then {
         $0.isSecureTextEntry = true
         $0.rightView = onPasswordButton
         $0.rightViewMode = .always
     }
 
-    lazy var onPasswordButton = UIButton().then {
-        $0.setImage(.image.on.image, for: .normal)
-        $0.addTarget(self, action: #selector(onPasswordButtonTapped), for: .touchUpInside)
-        $0.isEnabled = true
-    }
-
-    private let checkPasswordTextField = GOMSTextField(frame: .zero, placeholder: "비밀번호 확인").then {
+    private let checkPasswordTextField = GOMSTextField(frame: .zero, placeholder: "비밀번호를 다시 입력해주세요").then {
         $0.isSecureTextEntry = true
     }
 
-    private let conditionsLabel = UILabel().then {
-        $0.text = "대/소문자, 숫자, 특수문자 포함 6자 이상"
-        $0.font = .suit(size: 16, weight: .regular)
-        $0.textColor = .color.sub2.color
+    lazy var onPasswordButton = UIButton().then {
+        $0.setImage(.image.on.image.withRenderingMode(.alwaysTemplate), for: .normal)
+        $0.tintColor = .color.sub2.color
+        $0.adjustsImageWhenHighlighted = false
+        $0.addTarget(self, action: #selector(onPasswordButtonTapped), for: .touchUpInside)
     }
 
-    private let passwordError = UILabel().then {
-        $0.text = "비밀번호가 일치하지 않습니다."
+    private let passwordFormatError = UILabel().then {
+        $0.text = "잘못된 형식의 비밀번호입니다"
         $0.textColor = .color.gomsNegative.color
         $0.font = .suit(size: 16, weight: .medium)
+        $0.textAlignment = .right
+        $0.numberOfLines = 0
         $0.isHidden = true
+    }
+
+    private let passwordMatchError = UILabel().then {
+        $0.text = "비밀번호가 일치하지 않습니다"
+        $0.textColor = .color.gomsNegative.color
+        $0.font = .suit(size: 16, weight: .medium)
+        $0.textAlignment = .right
+        $0.numberOfLines = 0
+        $0.isHidden = true
+    }
+
+    private let conditionsLabel = UILabel().then {
+        $0.text = "비밀번호는 6자 이상이, 대/소문자, 숫자, 특수문자를 포함해 주세요"
+        $0.font = .suit(size: 16, weight: .regular)
+        $0.textColor = .color.sub2.color
+        $0.numberOfLines = 0
     }
 
     private lazy var signUpButton = GOMSButton(frame: .zero, title: "회원가입").then {
@@ -66,50 +86,182 @@ public final class PasswordSettingViewController: BaseViewController {
         super.viewDidLoad()
         passwordTextField.delegate = self
         checkPasswordTextField.delegate = self
+
+        passwordTextField.addTarget(self, action: #selector(passwordEditingChanged), for: .editingChanged)
+        checkPasswordTextField.addTarget(self, action: #selector(checkPasswordEditingChanged), for: .editingChanged)
+    }
+
+    @objc private func passwordEditingChanged() {
+
+        let password = passwordTextField.text ?? ""
+
+        
+        if password.isEmpty {
+            passwordFormatError.isHidden = true
+
+            passwordTextField.setPlaceholderColor(.color.sub2.color)
+
+            passwordTextField.layer.borderColor = UIColor.clear.cgColor
+            passwordTextField.layer.borderWidth = 0
+
+            return
+        }
+
+        let passwordRegex = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).{6,}$"
+        let passwordPredicate = NSPredicate(format: "SELF MATCHES %@", passwordRegex)
+
+        if !passwordPredicate.evaluate(with: password) {
+            passwordFormatError.isHidden = false
+            passwordFormatError.text = "잘못된 형식의 비밀번호입니다"
+
+            passwordTextField.layer.borderColor = UIColor.systemRed.cgColor
+            passwordTextField.layer.borderWidth = 1
+        } else {
+            passwordFormatError.isHidden = true
+
+            passwordTextField.layer.borderColor = UIColor.clear.cgColor
+            passwordTextField.layer.borderWidth = 0
+        }
+
+        
+        let confirm = checkPasswordTextField.text ?? ""
+
+        if confirm.isEmpty {
+            passwordMatchError.isHidden = true
+            checkPasswordTextField.layer.borderColor = UIColor.clear.cgColor
+            checkPasswordTextField.layer.borderWidth = 0
+        } else if password == confirm {
+            passwordMatchError.isHidden = true
+            checkPasswordTextField.layer.borderColor = UIColor.clear.cgColor
+            checkPasswordTextField.layer.borderWidth = 0
+        } else {
+            passwordMatchError.isHidden = false
+            checkPasswordTextField.layer.borderColor = UIColor.systemRed.cgColor
+            checkPasswordTextField.layer.borderWidth = 1
+        }
+    }
+
+    @objc private func checkPasswordEditingChanged() {
+
+        let password = passwordTextField.text ?? ""
+        let confirm = checkPasswordTextField.text ?? ""
+
+        // 입력 없으면 초기 상태
+        if confirm.isEmpty {
+            passwordMatchError.isHidden = true
+            checkPasswordTextField.setPlaceholderColor(.color.sub2.color)
+            checkPasswordTextField.layer.borderColor = UIColor.clear.cgColor
+            checkPasswordTextField.layer.borderWidth = 0
+            return
+        }
+
+        // 비밀번호가 같으면 즉시 에러 제거
+        if password == confirm {
+            passwordMatchError.isHidden = true
+            checkPasswordTextField.layer.borderColor = UIColor.clear.cgColor
+            checkPasswordTextField.layer.borderWidth = 0
+            return
+        }
+
+        // 다르면 에러 표시
+        passwordMatchError.isHidden = false
+        checkPasswordTextField.layer.borderColor = UIColor.systemRed.cgColor
+        checkPasswordTextField.layer.borderWidth = 1
     }
 
     @objc private func signUpButtonTapped() {
+
+        if passwordTextField.text?.isEmpty == true {
+
+            passwordTextField.setPlaceholderColor(.color.gomsNegative.color)
+            passwordTextField.layer.borderColor = UIColor.systemRed.cgColor
+            passwordTextField.layer.borderWidth = 1
+
+            passwordFormatError.isHidden = false
+            passwordFormatError.text = "비밀번호를 입력해주세요"
+
+            return
+        }
+
+        let password = passwordTextField.text ?? ""
+        let passwordRegex = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).{6,}$"
+        let passwordPredicate = NSPredicate(format: "SELF MATCHES %@", passwordRegex)
+
+        if !passwordPredicate.evaluate(with: password) {
+
+            passwordTextField.layer.borderColor = UIColor.systemRed.cgColor
+            passwordTextField.layer.borderWidth = 1
+
+            passwordFormatError.isHidden = false
+            passwordFormatError.text = "잘못된 형식의 비밀번호입니다"
+
+            return
+        }
+
+      
+        if passwordTextField.text != checkPasswordTextField.text {
+
+            passwordMatchError.isHidden = false
+
+            checkPasswordTextField.layer.borderColor = UIColor.systemRed.cgColor
+            checkPasswordTextField.layer.borderWidth = 1
+
+            return
+        } else {
+
+            passwordMatchError.isHidden = true
+            checkPasswordTextField.layer.borderColor = UIColor.clear.cgColor
+            checkPasswordTextField.layer.borderWidth = 0
+        }
 
         viewModel.setupNewPassword(
             newPassword: passwordTextField.text ?? "",
             checkPassword: checkPasswordTextField.text ?? ""
         )
 
-        DispatchQueue.main.async {
-            self.present(self.loader, animated: true)
-        }
+       
+        self.signUpSuccessUI()
 
-        viewModel.signUp { success in
+        let alert = UIAlertController(
+            title: "회원가입 완료",
+            message: "회원가입이 완료되었습니다.",
+            preferredStyle: .alert
+        )
 
-            if success {
+        alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
 
-                self.signUpSuccessUI()
-                let signInVC = SignInViewController(viewModel: self.viewModel)
-                self.navigationController?.pushViewController(signInVC, animated: true)
-                self.loader.dismiss(animated: true)
+            let introVC = IntroViewController()
+            let nav = UINavigationController(rootViewController: introVC)
 
-            } else {
-
-                self.passwordErrorUI()
-                self.loader.dismiss(animated: true)
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let window = windowScene.windows.first {
+                window.rootViewController = nav
+                window.makeKeyAndVisible()
             }
-        }
+        })
+
+        self.present(alert, animated: true)
     }
 
     private func signUpSuccessUI() {
         checkPasswordTextField.setPlaceholderColor(.color.mainText.color)
-        passwordError.isHidden = true
+        passwordFormatError.isHidden = true
+        passwordMatchError.isHidden = true
+        passwordFormatError.isHidden = true
+        passwordMatchError.isHidden = true
         checkPasswordTextField.layer.borderColor = UIColor.clear.cgColor
         checkPasswordTextField.layer.borderWidth = 0
-        conditionsLabel.isHidden = false
+
     }
 
     private func passwordErrorUI() {
         checkPasswordTextField.setPlaceholderColor(.color.gomsNegative.color)
-        passwordError.isHidden = false
+
+        passwordMatchError.isHidden = false
+
         checkPasswordTextField.layer.borderColor = UIColor.systemRed.cgColor
         checkPasswordTextField.layer.borderWidth = 1
-        conditionsLabel.isHidden = true
+
     }
 
     @objc private func onPasswordButtonTapped() {
@@ -117,50 +269,66 @@ public final class PasswordSettingViewController: BaseViewController {
         passwordTextField.isSelected.toggle()
 
         if passwordTextField.isSelected {
-            onPasswordButton.setImage(.image.off.image, for: .normal)
+            onPasswordButton.setImage(.image.off.image.withRenderingMode(.alwaysTemplate), for: .normal)
         } else {
-            onPasswordButton.setImage(.image.on.image, for: .normal)
+            onPasswordButton.setImage(.image.on.image.withRenderingMode(.alwaysTemplate), for: .normal)
         }
     }
 
     @objc public override func keyboardWillShow(_ sender: Notification) {
-        signUpButton.snp.remakeConstraints {
-            $0.leading.equalTo(bounds.width * 0.05)
-            $0.trailing.equalTo(-bounds.width * 0.05)
-            $0.bottom.equalTo(-bounds.height * 0.42)
-            $0.height.equalTo(48)
+        guard
+            let userInfo = sender.userInfo,
+            let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+            let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
+
+        let keyboardHeight = keyboardFrame.height - view.safeAreaInsets.bottom
+
+        signUpButton.snp.updateConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-(keyboardHeight + 24))
+        }
+
+        UIView.animate(withDuration: duration) {
+            self.view.layoutIfNeeded()
         }
     }
 
     @objc public override func keyboardWillHide(_ sender: Notification) {
-        signUpButton.snp.remakeConstraints {
-            $0.leading.equalTo(bounds.width * 0.05)
-            $0.trailing.equalTo(-bounds.width * 0.05)
-            $0.bottom.equalTo(-bounds.height * 0.16)
-            $0.height.equalTo(48)
-        }
-    }
+        guard
+            let userInfo = sender.userInfo,
+            let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
 
-    public override func configNavigation() {
-        super.configNavigation()
-        navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.title = "비밀번호 설정"
+        signUpButton.snp.updateConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-24)
+        }
+
+        UIView.animate(withDuration: duration) {
+            self.view.layoutIfNeeded()
+        }
     }
 
     public override func addView() {
 
-        [passwordTextField, checkPasswordTextField]
-            .forEach { textFieldStackView.addArrangedSubview($0) }
+        textFieldStackView.addArrangedSubview(passwordTextField)
+        textFieldStackView.addArrangedSubview(passwordFormatError)
+        textFieldStackView.addArrangedSubview(checkPasswordTextField)
+        textFieldStackView.addArrangedSubview(passwordMatchError)
 
         [
+            pageTitleLabel,
             textFieldStackView,
             conditionsLabel,
-            passwordError,
             signUpButton
         ].forEach { view.addSubview($0) }
     }
 
     public override func setLayout() {
+
+        pageTitleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(124)
+            $0.leading.equalTo(20)
+        }
 
         passwordTextField.snp.makeConstraints { $0.height.equalTo(56) }
         checkPasswordTextField.snp.makeConstraints { $0.height.equalTo(56) }
@@ -168,26 +336,20 @@ public final class PasswordSettingViewController: BaseViewController {
         textFieldStackView.snp.makeConstraints {
             $0.leading.equalTo(bounds.width * 0.05)
             $0.trailing.equalTo(-bounds.width * 0.05)
-            $0.top.equalTo(bounds.height * 0.21)
+            $0.top.equalTo(pageTitleLabel.snp.bottom).offset(24)
         }
 
         conditionsLabel.snp.makeConstraints {
-            $0.height.equalTo(48)
-            $0.top.equalTo(textFieldStackView.snp.bottom)
+            $0.top.equalTo(textFieldStackView.snp.bottom).offset(12)
             $0.leading.equalTo(bounds.width * 0.07)
-        }
-
-        passwordError.snp.makeConstraints {
-            $0.height.equalTo(48)
-            $0.top.equalTo(textFieldStackView.snp.bottom)
-            $0.leading.equalTo(bounds.width * 0.07)
+            $0.trailing.equalTo(-bounds.width * 0.05)
         }
 
         signUpButton.snp.makeConstraints {
-            $0.leading.equalTo(bounds.width * 0.05)
-            $0.trailing.equalTo(-bounds.width * 0.05)
-            $0.bottom.equalTo(-bounds.height * 0.16)
             $0.height.equalTo(48)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide).offset(-24)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-24)
         }
     }
 }

--- a/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
@@ -80,6 +80,8 @@ public final class SignUpViewController: BaseViewController {
 
         nameTextField.delegate = self
         emailTextField.delegate = self
+        nameTextField.addTarget(self, action: #selector(nameEditingChanged(_:)), for: .editingChanged)
+        emailTextField.addTarget(self, action: #selector(emailEditingChanged(_:)), for: .editingChanged)
 
         authCodeButton.isEnabled = shouldEnableAuthCodeButton()
     }
@@ -166,63 +168,13 @@ public final class SignUpViewController: BaseViewController {
             return
         }
 
-        DispatchQueue.main.async {
-            self.present(self.loader, animated: true)
-        }
+        let authCodeVC = AuthCodeViewController(
+            viewModel: self.viewModel,
+            previousViewController: self,
+            email: email
+        )
 
-        viewModel.setupEmail(email: emailTextField.text ?? "")
-        viewModel.setupName(name: nameTextField.text ?? "")
-        viewModel.setupEmailStatus(emailStatus: "BEFORE_SIGNUP")
-
-        viewModel.sendAuthCode { [weak self] success, statusCode in
-            guard let self = self else { return }
-
-            DispatchQueue.main.async {
-
-                if success {
-                    switch statusCode {
-                    case 200:
-                        let authCodeVC = AuthCodeViewController(
-                            viewModel: self.viewModel,
-                            previousViewController: self,
-                            email: self.emailTextField.text ?? ""
-                        )
-                        self.navigationController?.pushViewController(authCodeVC, animated: true)
-                        self.loader.dismiss(animated: true)
-
-                    default:
-                        let alert = UIAlertController(title: "서버오류",
-                                                      message: "GOMS 서버  운영팀에게 문의주세요.",
-                                                      preferredStyle: .alert)
-                        alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-                        self.present(alert, animated: true)
-                        self.loader.dismiss(animated: true)
-                    }
-                } else {
-                    switch statusCode {
-                    case 429:
-                        let alert = UIAlertController(
-                            title: "이메일 요청 초과",
-                            message: "이메일 요청 한도인 5번을 초과했습니다.\n5분 후에 재시도해 주세요.",
-                            preferredStyle: .alert
-                        )
-                        alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-                        self.present(alert, animated: true)
-                        self.loader.dismiss(animated: true)
-
-                    default:
-                        let alert = UIAlertController(
-                            title: "인증코드 발송 실패",
-                            message: "인증코드 발송에 실패했습니다.\n다시 시도해 주세요.",
-                            preferredStyle: .alert
-                        )
-                        alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-                        self.present(alert, animated: true)
-                        self.loader.dismiss(animated: true)
-                    }
-                }
-            }
-        }
+        self.navigationController?.pushViewController(authCodeVC, animated: true)
     }
 
 
@@ -311,6 +263,43 @@ public final class SignUpViewController: BaseViewController {
             .contains(genderTextField.title(for: .normal) ?? "")
 
         return nameValid && emailValid && majorValid && genderValid
+    }
+
+    @objc private func nameEditingChanged(_ textField: UITextField) {
+        let name = textField.text ?? ""
+
+        if name.isEmpty {
+            nameErrorLabel.isHidden = true
+            nameErrorLabel.snp.updateConstraints { $0.height.equalTo(0) }
+        } else {
+            nameErrorLabel.isHidden = true
+            nameErrorLabel.snp.updateConstraints { $0.height.equalTo(0) }
+        }
+
+        viewModel.setupName(name: name)
+        authCodeButton.isEnabled = shouldEnableAuthCodeButton()
+    }
+
+    @objc private func emailEditingChanged(_ textField: UITextField) {
+        let email = textField.text ?? ""
+
+        let emailRegex = "^s[0-9]{5}$"
+        let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
+
+        if email.isEmpty {
+            emailErrorLabel.isHidden = true
+            emailErrorLabel.snp.updateConstraints { $0.height.equalTo(0) }
+        } else if !emailPredicate.evaluate(with: email) {
+            emailErrorLabel.isHidden = false
+            emailErrorLabel.text = "올바른 이메일 형식이 아닙니다."
+            emailErrorLabel.snp.updateConstraints { $0.height.equalTo(19) }
+        } else {
+            emailErrorLabel.isHidden = true
+            emailErrorLabel.snp.updateConstraints { $0.height.equalTo(0) }
+        }
+
+        viewModel.setupEmail(email: email)
+        authCodeButton.isEnabled = shouldEnableAuthCodeButton()
     }
 
     @objc private func dismissKeyboard() {

--- a/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
@@ -83,7 +83,7 @@ public final class SignUpViewController: BaseViewController {
         nameTextField.addTarget(self, action: #selector(nameEditingChanged(_:)), for: .editingChanged)
         emailTextField.addTarget(self, action: #selector(emailEditingChanged(_:)), for: .editingChanged)
 
-        authCodeButton.isEnabled = shouldEnableAuthCodeButton()
+        authCodeButton.isEnabled = true
     }
 
     @objc private func genderButtonTapped() {
@@ -95,14 +95,16 @@ public final class SignUpViewController: BaseViewController {
             self.genderTextField.setTitle("남성", for: .normal)
             self.genderTextField.setTitleColor(.color.mainText.color, for: .normal)
             self.viewModel.setupGender(gender: Gender.man.rawValue)
-            self.authCodeButton.isEnabled = self.shouldEnableAuthCodeButton()
+            self.genderTextField.layer.borderWidth = 0
+            self.genderTextField.layer.borderColor = UIColor.clear.cgColor
         }
 
         let womanAction = UIAlertAction(title: "여성", style: .default) { _ in
             self.genderTextField.setTitle("여성", for: .normal)
             self.genderTextField.setTitleColor(.color.mainText.color, for: .normal)
             self.viewModel.setupGender(gender: Gender.man.rawValue)
-            self.authCodeButton.isEnabled = self.shouldEnableAuthCodeButton()
+            self.genderTextField.layer.borderWidth = 0
+            self.genderTextField.layer.borderColor = UIColor.clear.cgColor
         }
 
         [menAction, womanAction].forEach { alert.addAction($0) }
@@ -118,21 +120,24 @@ public final class SignUpViewController: BaseViewController {
             self.majorTextField.setTitle("SW개발과", for: .normal)
             self.majorTextField.setTitleColor(.color.mainText.color, for: .normal)
             self.viewModel.setupMajor(major: Major.sw.rawValue)
-            self.authCodeButton.isEnabled = self.shouldEnableAuthCodeButton()
+            self.majorTextField.layer.borderWidth = 0
+            self.majorTextField.layer.borderColor = UIColor.clear.cgColor
         }
 
         let iotAction = UIAlertAction(title: "스마트IoT과", style: .default) { _ in
             self.majorTextField.setTitle("스마트IoT과", for: .normal)
             self.majorTextField.setTitleColor(.color.mainText.color, for: .normal)
             self.viewModel.setupMajor(major: Major.iot.rawValue)
-            self.authCodeButton.isEnabled = self.shouldEnableAuthCodeButton()
+            self.majorTextField.layer.borderWidth = 0
+            self.majorTextField.layer.borderColor = UIColor.clear.cgColor
         }
 
         let aiAction = UIAlertAction(title: "AI개발과", style: .default) { _ in
             self.majorTextField.setTitle("AI개발과", for: .normal)
             self.majorTextField.setTitleColor(.color.mainText.color, for: .normal)
             self.viewModel.setupMajor(major: Major.ai.rawValue)
-            self.authCodeButton.isEnabled = self.shouldEnableAuthCodeButton()
+            self.majorTextField.layer.borderWidth = 0
+            self.majorTextField.layer.borderColor = UIColor.clear.cgColor
         }
 
         [swAction, iotAction, aiAction].forEach { alert.addAction($0) }
@@ -153,6 +158,34 @@ public final class SignUpViewController: BaseViewController {
             nameErrorLabel.isHidden = false
             nameErrorLabel.text = "이름을 입력해주세요."
             nameErrorLabel.snp.updateConstraints { $0.height.equalTo(19) }
+
+            nameTextField.layer.borderWidth = 1
+            nameTextField.layer.borderColor = UIColor.color.gomsNegative.color.cgColor
+            nameTextField.attributedPlaceholder = NSAttributedString(
+                string: "이름을 입력해주세요",
+                attributes: [
+                    .foregroundColor: UIColor.color.gomsNegative.color
+                ]
+            )
+
+            view.layoutIfNeeded()
+            return
+        }
+
+        if email.isEmpty {
+            emailErrorLabel.isHidden = false
+            emailErrorLabel.text = "이메일을 입력해주세요."
+            emailErrorLabel.snp.updateConstraints { $0.height.equalTo(19) }
+
+            emailTextField.layer.borderWidth = 1
+            emailTextField.layer.borderColor = UIColor.color.gomsNegative.color.cgColor
+            emailTextField.attributedPlaceholder = NSAttributedString(
+                string: "이메일을 입력해주세요",
+                attributes: [
+                    .foregroundColor: UIColor.color.gomsNegative.color
+                ]
+            )
+
             view.layoutIfNeeded()
             return
         }
@@ -165,6 +198,22 @@ public final class SignUpViewController: BaseViewController {
             emailErrorLabel.text = "올바른 이메일 형식이 아닙니다."
             emailErrorLabel.snp.updateConstraints { $0.height.equalTo(19) }
             view.layoutIfNeeded()
+            return
+        }
+
+        
+        let gender = genderTextField.title(for: .normal) ?? ""
+        let major = majorTextField.title(for: .normal) ?? ""
+
+        if gender == "성별" {
+            genderTextField.layer.borderWidth = 1
+            genderTextField.layer.borderColor = UIColor.color.gomsNegative.color.cgColor
+            return
+        }
+
+        if major == "과" {
+            majorTextField.layer.borderWidth = 1
+            majorTextField.layer.borderColor = UIColor.color.gomsNegative.color.cgColor
             return
         }
 
@@ -254,19 +303,17 @@ public final class SignUpViewController: BaseViewController {
         }
     }
 
-    private func shouldEnableAuthCodeButton() -> Bool {
-        let nameValid = !(nameTextField.text ?? "").isEmpty
-        let emailValid = (emailTextField.text ?? "").count == 6
-        let majorValid = ["SW개발과", "스마트IoT과", "AI개발과"]
-            .contains(majorTextField.title(for: .normal) ?? "")
-        let genderValid = ["남성", "여성"]
-            .contains(genderTextField.title(for: .normal) ?? "")
-
-        return nameValid && emailValid && majorValid && genderValid
-    }
-
     @objc private func nameEditingChanged(_ textField: UITextField) {
         let name = textField.text ?? ""
+
+        nameTextField.layer.borderWidth = 0
+        nameTextField.layer.borderColor = UIColor.clear.cgColor
+        nameTextField.attributedPlaceholder = NSAttributedString(
+            string: "이름을 입력해주세요",
+            attributes: [
+                .foregroundColor: UIColor.color.sub2.color
+            ]
+        )
 
         if name.isEmpty {
             nameErrorLabel.isHidden = true
@@ -277,11 +324,20 @@ public final class SignUpViewController: BaseViewController {
         }
 
         viewModel.setupName(name: name)
-        authCodeButton.isEnabled = shouldEnableAuthCodeButton()
+        view.layoutIfNeeded()
     }
 
     @objc private func emailEditingChanged(_ textField: UITextField) {
         let email = textField.text ?? ""
+
+        emailTextField.layer.borderWidth = 0
+        emailTextField.layer.borderColor = UIColor.clear.cgColor
+        emailTextField.attributedPlaceholder = NSAttributedString(
+            string: "이메일을 입력해주세요",
+            attributes: [
+                .foregroundColor: UIColor.color.sub2.color
+            ]
+        )
 
         let emailRegex = "^s[0-9]{5}$"
         let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
@@ -299,7 +355,7 @@ public final class SignUpViewController: BaseViewController {
         }
 
         viewModel.setupEmail(email: email)
-        authCodeButton.isEnabled = shouldEnableAuthCodeButton()
+        view.layoutIfNeeded()
     }
 
     @objc private func dismissKeyboard() {
@@ -349,8 +405,6 @@ extension SignUpViewController: UITextFieldDelegate {
         } else if textField == emailTextField {
             viewModel.setupEmail(email: emailTextField.text ?? "")
         }
-
-        authCodeButton.isEnabled = shouldEnableAuthCodeButton()
     }
 
     public func textField(_ textField: UITextField,

--- a/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
@@ -20,19 +20,19 @@ public final class SignUpViewController: BaseViewController {
     }
 
     private lazy var textFieldStackView = UIStackView().then {
-        $0.spacing = 32
+        $0.spacing = 16
         $0.axis = .vertical
         $0.distribution = .fillEqually
         $0.alignment = .fill
     }
 
-    let nameTextField = GOMSTextField(frame: .zero, placeholder: "이름")
+    let nameTextField = GOMSTextField(frame: .zero, placeholder: "이름을 입력해주세요")
 
-    private let emailTextField = GOMSTextField(frame: .zero, placeholder: "이메일")
+    private let emailTextField = GOMSTextField(frame: .zero, placeholder: "이메일을 입력해주세요")
 
     private let defaultDomain = UILabel().then {
         $0.text = "@gsm.hs.kr"
-        $0.font = .suit(size: 16, weight: .regular)
+        $0.font = .suit(size: 16, weight: .medium)
         $0.textColor = .color.sub2.color
     }
 
@@ -40,6 +40,22 @@ public final class SignUpViewController: BaseViewController {
         $0.text = "입력되지 않았습니다."
         $0.textColor = .color.gomsNegative.color
         $0.font = .suit(size: 16, weight: .medium)
+        $0.isHidden = true
+    }
+
+    private let nameErrorLabel = UILabel().then {
+        $0.text = "이름을 입력해주세요."
+        $0.textColor = .color.gomsNegative.color
+        $0.font = .suit(size: 15, weight: .medium)
+        $0.textAlignment = .right
+        $0.isHidden = true
+    }
+
+    private let emailErrorLabel = UILabel().then {
+        $0.text = "올바른 이메일 형식이 아닙니다."
+        $0.textColor = .color.gomsNegative.color
+        $0.font = .suit(size: 15, weight: .medium)
+        $0.textAlignment = .right
         $0.isHidden = true
     }
 
@@ -122,6 +138,34 @@ public final class SignUpViewController: BaseViewController {
     }
 
     @objc private func authCodeButtonTapped() {
+        let name = nameTextField.text ?? ""
+        let email = emailTextField.text ?? ""
+
+        nameErrorLabel.isHidden = true
+        emailErrorLabel.isHidden = true
+
+        nameErrorLabel.snp.updateConstraints { $0.height.equalTo(0) }
+        emailErrorLabel.snp.updateConstraints { $0.height.equalTo(0) }
+
+        if name.isEmpty {
+            nameErrorLabel.isHidden = false
+            nameErrorLabel.text = "이름을 입력해주세요."
+            nameErrorLabel.snp.updateConstraints { $0.height.equalTo(19) }
+            view.layoutIfNeeded()
+            return
+        }
+
+        let emailRegex = "^s[0-9]{5}$"
+        let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
+
+        if !emailPredicate.evaluate(with: email) {
+            emailErrorLabel.isHidden = false
+            emailErrorLabel.text = "올바른 이메일 형식이 아닙니다."
+            emailErrorLabel.snp.updateConstraints { $0.height.equalTo(19) }
+            view.layoutIfNeeded()
+            return
+        }
+
         DispatchQueue.main.async {
             self.present(self.loader, animated: true)
         }
@@ -186,19 +230,63 @@ public final class SignUpViewController: BaseViewController {
     public override func addView() {
         emailTextField.addSubview(defaultDomain)
 
-        [nameTextField, emailTextField, genderTextField, majorTextField]
-            .forEach { textFieldStackView.addArrangedSubview($0) }
-
-        [pageTitleLabel, textFieldStackView, authCodeButton]
+        [pageTitleLabel,
+         nameTextField,
+         nameErrorLabel,
+         emailTextField,
+         emailErrorLabel,
+         genderTextField,
+         majorTextField,
+         authCodeButton]
             .forEach { view.addSubview($0) }
     }
 
     public override func setLayout() {
 
-        nameTextField.snp.makeConstraints { $0.height.equalTo(56) }
-        emailTextField.snp.makeConstraints { $0.height.equalTo(56) }
-        genderTextField.snp.makeConstraints { $0.height.equalTo(56) }
-        majorTextField.snp.makeConstraints { $0.height.equalTo(56) }
+        pageTitleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(124)
+            $0.leading.equalTo(20)
+        }
+
+        nameTextField.snp.makeConstraints {
+            $0.leading.equalTo(bounds.width * 0.05)
+            $0.trailing.equalTo(-bounds.width * 0.05)
+            $0.top.equalTo(pageTitleLabel.snp.bottom).offset(24)
+            $0.height.equalTo(56)
+        }
+
+        nameErrorLabel.snp.makeConstraints {
+            $0.trailing.equalTo(nameTextField.snp.trailing)
+            $0.top.equalTo(nameTextField.snp.bottom).offset(8)
+            $0.height.equalTo(0)
+        }
+
+        emailTextField.snp.makeConstraints {
+            $0.leading.equalTo(bounds.width * 0.05)
+            $0.trailing.equalTo(-bounds.width * 0.05)
+            $0.top.equalTo(nameErrorLabel.snp.bottom).offset(16)
+            $0.height.equalTo(56)
+        }
+
+        emailErrorLabel.snp.makeConstraints {
+            $0.trailing.equalTo(emailTextField.snp.trailing)
+            $0.top.equalTo(emailTextField.snp.bottom).offset(8)
+            $0.height.equalTo(0)
+        }
+
+        genderTextField.snp.makeConstraints {
+            $0.leading.equalTo(bounds.width * 0.05)
+            $0.trailing.equalTo(-bounds.width * 0.05)
+            $0.top.equalTo(emailErrorLabel.snp.bottom).offset(16)
+            $0.height.equalTo(56)
+        }
+
+        majorTextField.snp.makeConstraints {
+            $0.leading.equalTo(bounds.width * 0.05)
+            $0.trailing.equalTo(-bounds.width * 0.05)
+            $0.top.equalTo(genderTextField.snp.bottom).offset(16)
+            $0.height.equalTo(56)
+        }
 
         defaultDomain.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
@@ -206,22 +294,11 @@ public final class SignUpViewController: BaseViewController {
             $0.centerY.equalToSuperview()
         }
 
-        pageTitleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(124)
-            $0.leading.equalTo(20)
-        }
-
-        textFieldStackView.snp.makeConstraints {
-            $0.top.equalTo(pageTitleLabel.snp.bottom).offset(24)
-            $0.leading.equalTo(bounds.width * 0.05)
-            $0.trailing.equalTo(-bounds.width * 0.05)
-        }
-
         authCodeButton.snp.makeConstraints {
-            $0.leading.equalTo(bounds.width * 0.05)
-            $0.trailing.equalTo(-bounds.width * 0.05)
-            $0.bottom.equalTo(-bounds.height * 0.16)
             $0.height.equalTo(48)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide).offset(-24)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-24)
         }
     }
 
@@ -238,6 +315,39 @@ public final class SignUpViewController: BaseViewController {
 
     @objc private func dismissKeyboard() {
         view.endEditing(true)
+    }
+
+    @objc public override func keyboardWillShow(_ sender: Notification) {
+        guard
+            let userInfo = sender.userInfo,
+            let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+            let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
+
+        let keyboardHeight = keyboardFrame.height - view.safeAreaInsets.bottom
+
+        authCodeButton.snp.updateConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-(keyboardHeight + 24))
+        }
+
+        UIView.animate(withDuration: duration) {
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    @objc public override func keyboardWillHide(_ sender: Notification) {
+        guard
+            let userInfo = sender.userInfo,
+            let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
+
+        authCodeButton.snp.updateConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-24)
+        }
+
+        UIView.animate(withDuration: duration) {
+            self.view.layoutIfNeeded()
+        }
     }
 }
 

--- a/Projects/Feature/Sources/View/GOMSTextFieldButton.swift
+++ b/Projects/Feature/Sources/View/GOMSTextFieldButton.swift
@@ -20,7 +20,7 @@ public class GOMSTextFieldButton: UIButton {
     }
     
     func setButton(withTitle title: String) {
-        setButtonBackgroundColor(lightModeColor: UIColor(red: 0, green: 0, blue: 0, alpha: 0.05), darkModeColor: UIColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1))
+        backgroundColor = .color.surface.color
         setTitle(title, for: .normal)
         setTitleColor(.color.sub2.color, for: .normal)
         titleLabel?.font = .suit(size: 16, weight: .regular)


### PR DESCRIPTION
# 🍎 개요
회원가입 과정에서 필요한 인증번호 확인 및 비밀번호 설정 화면을 구현하고
입력 검증 및 에러 UI 처리 로직을 추가

# 📦 작업내용
- AuthCodeViewController 인증번호 입력 화면 구현
- 인증번호 더미 검증 로직 추가 (1234)
- 인증번호 재발송 버튼 및 타이머 UI 구현
- 인증번호 확인 완료 Alert 추가
- 비밀번호 설정 화면 UI 구현
- 비밀번호 형식 실시간 검증 로직 추가
- 비밀번호 확인 불일치 검증 로직 추가
- TextField 에러 상태 UI 처리 (빨간 테두리 및 에러 메시지)
- 에러 메시지 표시 시 레이아웃 자동 이동 처리
- 회원가입 완료 Alert 추가
- 회원가입 완료 후 Intro 화면 루트 전환 로직 구현
