### PR TITLE
🔀 :: #79 MapView 전환 구조 개선 및 마이페이지 container 전환, 탭바 중복 문제 해결

### DIFF
--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -91,7 +91,10 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
         $0.backgroundColor = .clear
     }
 
-    private let tabBar = TabBar()
+private let tabBar = TabBar()
+
+private let mapContainerView = UIView()
+private let mapVC = MapViewController()
     
     private lazy var qrButton = AdminQRButton(
         frame: CGRect(x: 0, y: 0, width: 64, height: 64),
@@ -159,6 +162,12 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
         refreshControl.beginRefreshing()
         fetchData()
         bindTabBar()
+        setupMapContainer()
+        mapContainerView.isHidden = true
+        view.bringSubviewToFront(mapContainerView)
+        view.bringSubviewToFront(tabBar)
+        view.bringSubviewToFront(qrButton)
+        view.bringSubviewToFront(codeButton)
     }
 
 
@@ -349,16 +358,24 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
 
             switch tab {
             case .home:
-                let adminVC = AdminMainViewController()
-                self.navigationController?.setViewControllers([adminVC], animated: false)
+                self.mapContainerView.isHidden = true
+                self.scrollView.isHidden = false
             case .map:
-                let mapVC = MapViewController()
-                self.navigationController?.pushViewController(mapVC, animated: false)
+                self.mapContainerView.isHidden = false
+                self.scrollView.isHidden = true
             case .profile:
                 let profileVC = AdminProfileViewController()
-                self.navigationController?.setViewControllers([profileVC], animated: false)
+                self.navigationController?.pushViewController(profileVC, animated: true)
             }
         }
+    }
+
+    private func setupMapContainer() {
+        addChild(mapVC)
+        mapContainerView.addSubview(mapVC.view)
+        mapVC.view.frame = mapContainerView.bounds
+        mapVC.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapVC.didMove(toParent: self)
     }
     // MARK: - Selector
     @objc func moreOutingStatusButtonTapped() {
@@ -426,6 +443,7 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
 
         [outingStatusLabel, moreOutingStatusButton, outingCountLabel, outingStatusCollectionView].forEach { self.outingView.addSubview($0) }
         [logo, profileView, basicsProfileView, latecomerLabel, lateNilView, latecomerCollectionView, outingView].forEach { self.contentView.addSubview($0) }
+        view.addSubview(mapContainerView)
         view.addSubview(tabBar)
         view.addSubview(qrButton)
         view.addSubview(codeButton)
@@ -489,6 +507,12 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
             $0.leading.trailing.equalToSuperview()
             $0.top.equalTo(latecomerCollectionView.snp.bottom).offset(24)
             $0.bottom.equalTo(contentView.snp.bottom).offset(-100)
+        }
+
+        mapContainerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(tabBar.snp.top)
         }
 
         outingStatusLabel.snp.makeConstraints {

--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -349,19 +349,10 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
 
             switch tab {
             case .home:
-               
                 let adminVC = AdminMainViewController()
                 self.navigationController?.setViewControllers([adminVC], animated: false)
             case .map:
                 let mapVC = MapViewController()
-
-                
-                let transition = CATransition()
-                transition.duration = 0.25
-                transition.type = .push
-                transition.subtype = .fromLeft
-                navigationController?.view.layer.add(transition, forKey: kCATransition)
-
                 self.navigationController?.pushViewController(mapVC, animated: false)
             case .profile:
                 let profileVC = AdminProfileViewController()

--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -95,6 +95,8 @@ private let tabBar = TabBar()
 
 private let mapContainerView = UIView()
 private let mapVC = MapViewController()
+private let profileContainerView = UIView()
+private let profileVC = AdminProfileViewController()
     
     private lazy var qrButton = AdminQRButton(
         frame: CGRect(x: 0, y: 0, width: 64, height: 64),
@@ -163,8 +165,14 @@ private let mapVC = MapViewController()
         fetchData()
         bindTabBar()
         setupMapContainer()
+        setupProfileContainer()
+
         mapContainerView.isHidden = true
+        profileContainerView.isHidden = true
+
+       
         view.bringSubviewToFront(mapContainerView)
+        view.bringSubviewToFront(profileContainerView)
         view.bringSubviewToFront(tabBar)
         view.bringSubviewToFront(qrButton)
         view.bringSubviewToFront(codeButton)
@@ -356,20 +364,27 @@ private let mapVC = MapViewController()
         tabBar.onTabSelected = { [weak self] tab in
             guard let self = self else { return }
 
+            self.tabBar.updateSelectedTab(tab)
+
             switch tab {
             case .home:
                 self.mapContainerView.isHidden = true
+                self.profileContainerView.isHidden = true
                 self.scrollView.isHidden = false
                 self.qrButton.isHidden = false
                 self.codeButton.isHidden = false
             case .map:
                 self.mapContainerView.isHidden = false
+                self.profileContainerView.isHidden = true
                 self.scrollView.isHidden = true
                 self.qrButton.isHidden = true
                 self.codeButton.isHidden = true
             case .profile:
-                let profileVC = AdminProfileViewController()
-                self.navigationController?.pushViewController(profileVC, animated: true)
+                self.mapContainerView.isHidden = true
+                self.profileContainerView.isHidden = false
+                self.scrollView.isHidden = true
+                self.qrButton.isHidden = true
+                self.codeButton.isHidden = true
             }
         }
     }
@@ -380,6 +395,14 @@ private let mapVC = MapViewController()
         mapVC.view.frame = mapContainerView.bounds
         mapVC.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapVC.didMove(toParent: self)
+    }
+
+    private func setupProfileContainer() {
+        addChild(profileVC)
+        profileContainerView.addSubview(profileVC.view)
+        profileVC.view.frame = profileContainerView.bounds
+        profileVC.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        profileVC.didMove(toParent: self)
     }
     // MARK: - Selector
     @objc func moreOutingStatusButtonTapped() {
@@ -448,6 +471,7 @@ private let mapVC = MapViewController()
         [outingStatusLabel, moreOutingStatusButton, outingCountLabel, outingStatusCollectionView].forEach { self.outingView.addSubview($0) }
         [logo, profileView, basicsProfileView, latecomerLabel, lateNilView, latecomerCollectionView, outingView].forEach { self.contentView.addSubview($0) }
         view.addSubview(mapContainerView)
+        view.addSubview(profileContainerView)
         view.addSubview(tabBar)
         view.addSubview(qrButton)
         view.addSubview(codeButton)
@@ -514,6 +538,12 @@ private let mapVC = MapViewController()
         }
 
         mapContainerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(tabBar.snp.top)
+        }
+
+        profileContainerView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(tabBar.snp.top)

--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -360,9 +360,13 @@ private let mapVC = MapViewController()
             case .home:
                 self.mapContainerView.isHidden = true
                 self.scrollView.isHidden = false
+                self.qrButton.isHidden = false
+                self.codeButton.isHidden = false
             case .map:
                 self.mapContainerView.isHidden = false
                 self.scrollView.isHidden = true
+                self.qrButton.isHidden = true
+                self.codeButton.isHidden = true
             case .profile:
                 let profileVC = AdminProfileViewController()
                 self.navigationController?.pushViewController(profileVC, animated: true)

--- a/Projects/Feature/Sources/Scene/Main/View/TabBar.swift
+++ b/Projects/Feature/Sources/Scene/Main/View/TabBar.swift
@@ -51,6 +51,10 @@ public final class TabBar: UIView {
             updateSelectedState()
         }
     }
+
+    public func updateSelectedTab(_ tab: TabType) {
+        selectedTab = tab
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Projects/Feature/Sources/Scene/Map/View/MapViewController.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapViewController.swift
@@ -69,7 +69,7 @@ public final class MapViewController: UIViewController {
         }
         
         searchBar.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(64)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(8)
             $0.leading.trailing.equalToSuperview().inset(24)
             $0.height.equalTo(52)
         }

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
@@ -17,7 +17,6 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
     let imagePickerController = UIImagePickerController()
     let profileViewModel = ProfileViewModel()
     var cancellables = Set<AnyCancellable>()
-private let tabBarView = TabBar()
 
     let logo = UIImageView().then {
         $0.image = UIImage(
@@ -333,29 +332,6 @@ private let tabBarView = TabBar()
     }
 
 
-    private func bindTabBar() {
-        tabBarView.onTabSelected = { [weak self] tab in
-            guard let self = self else { return }
-
-            switch tab {
-            case .home:
-                let adminVC = AdminMainViewController()
-                self.navigationController?.setViewControllers([adminVC], animated: false)
-            case .map:
-                let mapVC = MapViewController()
-
-                let transition = CATransition()
-                transition.duration = 0.25
-                transition.type = .push
-                transition.subtype = .fromLeft
-                self.navigationController?.view.layer.add(transition, forKey: kCATransition)
-
-                self.navigationController?.pushViewController(mapVC, animated: false)
-            case .profile:
-                break
-            }
-        }
-    }
 
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -419,8 +395,6 @@ private let tabBarView = TabBar()
         
         view.backgroundColor = .color.background.color
 
-        tabBarView.selectedTab = .profile
-        bindTabBar()
         
         let backBarButtonItem = UIBarButtonItem(title: "돌아가기", style: .plain, target: self, action: nil)
         self.navigationItem.backBarButtonItem = backBarButtonItem
@@ -549,9 +523,7 @@ private let tabBarView = TabBar()
 
             passwordResetButton,
             logoutButton,
-            withdrawalButton,
-
-            tabBarView
+            withdrawalButton
         ].forEach {
             view.addSubview($0)
         }
@@ -698,11 +670,6 @@ private let tabBarView = TabBar()
 
 
 
-        tabBarView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalToSuperview()
-            $0.height.equalTo(100)
-        }
     }
 }
 


### PR DESCRIPTION
# 🍎 개요
MapView와 마이페이지 전환 방식을 navigation push에서 container 기반으로 변경하여
불필요한 애니메이션을 제거하고, 탭바 중복 및 UI 문제를 해결했습니다.

또한 MapView의 searchBar 여백 및 전환 시 발생하던 UI 이슈들을 함께 수정했습니다.

# 📦 작업 내용
- navigation push 방식 제거
- container 기반 화면 전환으로 변경
- 전환 시 애니메이션 제거
-  MapView searchBar 상단 여백을 safeArea 기준으로 수정
- Map 전환 시 qrButton, codeButton이 따라오는 문제 해결
- Mypage navigation push → container 방식으로 전환
- Mypage AdminMainViewController에서 화면 전환 통합 관리

Tabbar
- AdminProfileViewController 내부 TabBar 제거
- TabBar를 AdminMainViewController에서 단일 관리하도록 구조 수정
- 마이페이지 진입 시 탭바 중복 생성 문제 해결