### PR TITLE
🔀 :: #81 AdminMainView GOMS 로고 UI 메인뷰와 통일

### DIFF
--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -37,7 +37,13 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
 
     let content = UIView()
 
-    private let logo = UIImageView(image: .image.gomsLightGrayLogo.image)
+    private let logo = UIImageView().then {
+        $0.image = UIImage(
+            named: "graylogo",
+            in: Bundle.module,
+            compatibleWith: nil
+        )
+    }
 
     private lazy var adminMenuButton = ExpandableButton().then {
         $0.setBackgroundImage(.image.adminMenu.image, for: .normal)
@@ -511,9 +517,9 @@ private let profileVC = AdminProfileViewController()
 
         logo.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(20)
-            $0.top.equalTo(contentView.snp.top).offset(20)
-            $0.height.equalTo(24)
-            $0.width.equalTo(87)
+            $0.top.equalTo(contentView.snp.top)
+            $0.height.equalTo(56)
+            $0.width.equalTo(135)
         }
 
 


### PR DESCRIPTION
# 🍎 개요
AdminMainViewController의 GOMS 로고가
MainViewController와 다르게 적용되어 있어 UI를 통일했습니다.

# 📦 작업 내용
- AdminMainView GOMS 로고 이미지 MainView와 동일하게 수정
- 로고 크기 및 위치 MainView 기준으로 통일
- 상단 여백 제거하여 레이아웃 일치
