### PR TITLE
🔀 :: #87 유저/어드민 프로필 뷰 레이아웃 개선 및 시계 표시 기능 추가

### DIFF
--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -371,7 +371,7 @@ private let profileVC = AdminProfileViewController()
 
         profileView.profileStatus.text = "관리자"
         profileView.profileStatus.textColor = .color.admin.color
-        // ❗️ 겹치는 원인 제거 (lateCountLabel 숨김)
+
         profileView.lateCountLabel.isHidden = true
         profileView.lateCountLabel.text = ""
         profileView.isClockOn = isClockOn
@@ -592,7 +592,7 @@ private let profileVC = AdminProfileViewController()
             $0.bottom.equalToSuperview()
         }
 
-        // (Removed invalid studentInformationLabel constraint block)
+        
     }
 
     func updateLayout() {

--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -29,11 +29,13 @@ public class AdminMainViewController: BaseViewController, UICollectionViewDataSo
         $0.translatesAutoresizingMaskIntoConstraints = false
     }
 
-    var isClockOn: Bool = UserDefaults.standard.bool(forKey: "isClockOn") {
-        didSet {
-            updateLayout()
-        }
+var isClockOn: Bool = UserDefaults.standard.bool(forKey: "isClockOn") {
+    didSet {
+        basicsProfileView.isClockOn = isClockOn
+        profileView.isClockOn = isClockOn
+        updateLayout()
     }
+}
 
     let content = UIView()
 
@@ -133,6 +135,7 @@ private let profileVC = AdminProfileViewController()
         super.viewWillAppear(animated)
 
         isVisible = true
+        isClockOn = UserDefaults.standard.bool(forKey: "isClockOn")
 
         viewModel.getLateList { [weak self] in
             self?.viewModel.getOutingList { [weak self] in
@@ -345,24 +348,33 @@ private let profileVC = AdminProfileViewController()
             basicsProfileView.profileImageView.image = .image.profile.image
         }
 
-        profileView.nameLabel.text = viewModel.profileData?.name
-        basicsProfileView.nameLabel.text = viewModel.profileData?.name
-        basicsProfileView.lateCountLabel.isHidden = true
-
+        let majorText: String
         if viewModel.profileData?.major == Major.sw.rawValue {
-            profileView.studentInformationLabel.text = "\(grade)기 | SW개발"
-            basicsProfileView.studentInformationLabel.text = "\(grade)기 | SW개발"
+            majorText = "SW개발"
         } else if viewModel.profileData?.major == Major.iot.rawValue {
-            profileView.studentInformationLabel.text = "\(grade)기 | IoT"
-            basicsProfileView.studentInformationLabel.text = "\(grade)기 | IoT"
+            majorText = "IoT"
         } else {
-            profileView.studentInformationLabel.text = "\(grade)기 | AI"
-            basicsProfileView.studentInformationLabel.text = "\(grade)기 | AI"
+            majorText = "AI"
         }
 
-        basicsProfileView.myOutingStatusLabel.text = "관리자"
-        basicsProfileView.myOutingStatusLabel.textColor = .color.admin.color
+        profileView.nameLabel.text = viewModel.profileData?.name
+        profileView.studentInformationLabel.text = "\(grade)기 | \(majorText)"
+        profileView.isAdmin = true
+
+        basicsProfileView.configure(
+            name: viewModel.profileData?.name ?? "",
+            studentInfo: "\(grade)기 | \(majorText)",
+            lateCount: 0,
+            outingStatus: "관리자",
+            isAdmin: true
+        )
+
         profileView.profileStatus.text = "관리자"
+        profileView.profileStatus.textColor = .color.admin.color
+        // ❗️ 겹치는 원인 제거 (lateCountLabel 숨김)
+        profileView.lateCountLabel.isHidden = true
+        profileView.lateCountLabel.text = ""
+        profileView.isClockOn = isClockOn
     }
 
 
@@ -579,6 +591,8 @@ private let profileVC = AdminProfileViewController()
             $0.leading.trailing.equalToSuperview().inset(24)
             $0.bottom.equalToSuperview()
         }
+
+        // (Removed invalid studentInformationLabel constraint block)
     }
 
     func updateLayout() {
@@ -608,6 +622,8 @@ private let profileVC = AdminProfileViewController()
             basicsProfileView.isHidden = false
         }
 
+        basicsProfileView.isClockOn = isClockOn
+        profileView.isClockOn = isClockOn
         view.layoutIfNeeded()
     }
 

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -30,6 +30,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
 
     var isClockOn: Bool = UserDefaults.standard.bool(forKey: "isClockOn") {
         didSet {
+            profileView.isClockOn = isClockOn
             updateLayout()
         }
     }
@@ -656,6 +657,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
             basicsProfileView.isHidden = false
         }
 
+        profileView.isClockOn = isClockOn
         view.layoutIfNeeded()
     }
 

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -476,23 +476,25 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         basicsProfileView.lateCountLabel.text = "지각 횟수: \(mainViewModel.lateListDatas.count)회"
         profileView.lateCountLabel.text = "지각 횟수: \(mainViewModel.lateListDatas.count)회"
 
-        if let isBlackList = mainViewModel.profileData?.isBlackList, let isOuting = mainViewModel.profileData?.isOuting {
-            if isBlackList {
-                profileView.profileStatus.text = "외출 금지"
-                profileView.profileStatus.textColor = .color.gomsNegative.color
-                basicsProfileView.myOutingStatusLabel.text = "외출 금지"
-                basicsProfileView.myOutingStatusLabel.textColor = .color.gomsNegative.color
-            } else if isOuting {
-                profileView.profileStatus.text = "외출 중"
-                profileView.profileStatus.textColor = .color.gomsPrimary.color
-                basicsProfileView.myOutingStatusLabel.text = "외출 중"
-                basicsProfileView.myOutingStatusLabel.textColor = .color.gomsPrimary.color
-            } else {
-                profileView.profileStatus.text = "외출 대기 중"
-                profileView.profileStatus.textColor = .color.sub1.color
-                basicsProfileView.myOutingStatusLabel.text = "외출 대기 중"
-                basicsProfileView.myOutingStatusLabel.textColor = .color.sub1.color
-            }
+        
+        let isBlackList = false
+        let isOuting = true
+
+        if isBlackList {
+            profileView.profileStatus.text = "외출 금지"
+            profileView.profileStatus.textColor = .color.gomsNegative.color
+            basicsProfileView.myOutingStatusLabel.text = "외출 금지"
+            basicsProfileView.myOutingStatusLabel.textColor = .color.gomsNegative.color
+        } else if isOuting {
+            profileView.profileStatus.text = "외출 중"
+            profileView.profileStatus.textColor = .color.gomsPrimary.color
+            basicsProfileView.myOutingStatusLabel.text = "외출 중"
+            basicsProfileView.myOutingStatusLabel.textColor = .color.gomsPrimary.color
+        } else {
+            profileView.profileStatus.text = "외출 대기 중"
+            profileView.profileStatus.textColor = .color.sub1.color
+            basicsProfileView.myOutingStatusLabel.text = "외출 대기 중"
+            basicsProfileView.myOutingStatusLabel.textColor = .color.sub1.color
         }
     }
 

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -137,6 +137,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         navigationController?.pushViewController(outingVC, animated: true)
     }
 
+    
     @objc func qrButtonTapped() {
         qrButton.isUserInteractionEnabled = false
 
@@ -240,6 +241,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         isVisible = true
+                isClockOn = UserDefaults.standard.bool(forKey: "isClockOn")
 
         mainViewModel.getLateList { [weak self] in
             self?.mainViewModel.getOutingList { [weak self] in
@@ -271,6 +273,13 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         configureRefreshControl()
         updateSelectedTab()
         refreshControl.beginRefreshing()
+      
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleClockChanged),
+            name: Notification.Name("clockChanged"),
+            object: nil
+        )
     }
 
     func configureRefreshControl() {
@@ -464,6 +473,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
             basicsProfileView.studentInformationLabel.text = "\(grade)기 | AI"
         }
         basicsProfileView.lateCountLabel.text = "지각 횟수: \(mainViewModel.lateListDatas.count)회"
+        profileView.lateCountLabel.text = "지각 횟수: \(mainViewModel.lateListDatas.count)회"
 
         if let isBlackList = mainViewModel.profileData?.isBlackList, let isOuting = mainViewModel.profileData?.isOuting {
             if isBlackList {
@@ -647,6 +657,10 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         }
 
         view.layoutIfNeeded()
+    }
+
+    @objc private func handleClockChanged() {
+        isClockOn = UserDefaults.standard.bool(forKey: "isClockOn")
     }
 
     // MARK: - UICollectionViewDataSource

--- a/Projects/Feature/Sources/Scene/Main/View/MainProfileView.swift
+++ b/Projects/Feature/Sources/Scene/Main/View/MainProfileView.swift
@@ -17,8 +17,18 @@ public final class MainProfileView: UIView {
             didSet {
                 timeLabel.isHidden = !isClockOn
                 timeLabel.alpha = 0.6
+
+                updateStudentInfoLayout()
+                setNeedsLayout()
+                layoutIfNeeded()
+             
             }
         }
+    var isAdmin: Bool = false {
+        didSet {
+            updateStyle()
+        }
+    }
     
     // MARK: - Properties
     let profileImageView = UIImageView().then {
@@ -43,6 +53,14 @@ public final class MainProfileView: UIView {
         $0.font = UIFont.suit(size: 14, weight: .medium)
     }
 
+    private func updateStyle() {
+        if isAdmin {
+            studentInformationLabel.font = UIFont.suit(size: 15, weight: .medium)
+        } else {
+            studentInformationLabel.font = UIFont.suit(size: 15, weight: .medium)
+        }
+    }
+
     let profileStatus = UILabel().then {
         $0.text = ""
         $0.textColor = .color.sub1.color
@@ -64,7 +82,10 @@ public final class MainProfileView: UIView {
         configureUI()
         addView()
         setLayout()
+        updateStyle()
         startClock()
+    
+        
     }
     
     required init?(coder: NSCoder) {
@@ -92,11 +113,7 @@ public final class MainProfileView: UIView {
             $0.top.equalToSuperview().inset(16)
         }
 
-        studentInformationLabel.snp.remakeConstraints {
-            $0.leading.equalTo(nameLabel.snp.trailing).offset(8)
-            $0.centerY.equalTo(nameLabel)
-            $0.trailing.lessThanOrEqualTo(profileStatus.snp.leading).offset(-8)
-        }
+        updateStudentInfoLayout()
 
         lateCountLabel.snp.remakeConstraints {
             $0.leading.equalToSuperview().inset(20)
@@ -117,6 +134,31 @@ public final class MainProfileView: UIView {
     
         timeLabel.isHidden = !isClockOn
         
+    }
+
+    private func updateStudentInfoLayout() {
+        studentInformationLabel.snp.remakeConstraints {
+
+            if isAdmin {
+                // 🔥 어드민 → 항상 이름 아래
+                $0.leading.equalTo(nameLabel)
+                $0.top.equalTo(nameLabel.snp.bottom).offset(4)
+                $0.trailing.lessThanOrEqualTo(profileStatus.snp.leading).offset(-8)
+
+            } else {
+                if isClockOn {
+                    // 유저 + 시계 ON → 이름 오른쪽
+                    $0.leading.equalTo(nameLabel.snp.trailing).offset(8)
+                    $0.centerY.equalTo(nameLabel)
+                    $0.trailing.lessThanOrEqualTo(profileStatus.snp.leading).offset(-8)
+                } else {
+                    // 유저 + 시계 OFF → 이름 아래
+                    $0.leading.equalTo(nameLabel)
+                    $0.top.equalTo(nameLabel.snp.bottom).offset(4)
+                    $0.trailing.lessThanOrEqualTo(profileStatus.snp.leading).offset(-8)
+                }
+            }
+        }
     }
 
     private func startClock() {

--- a/Projects/Feature/Sources/Scene/Main/View/MainProfileView.swift
+++ b/Projects/Feature/Sources/Scene/Main/View/MainProfileView.swift
@@ -140,19 +140,19 @@ public final class MainProfileView: UIView {
         studentInformationLabel.snp.remakeConstraints {
 
             if isAdmin {
-                // 🔥 어드민 → 항상 이름 아래
+               
                 $0.leading.equalTo(nameLabel)
                 $0.top.equalTo(nameLabel.snp.bottom).offset(4)
                 $0.trailing.lessThanOrEqualTo(profileStatus.snp.leading).offset(-8)
 
             } else {
                 if isClockOn {
-                    // 유저 + 시계 ON → 이름 오른쪽
+                    
                     $0.leading.equalTo(nameLabel.snp.trailing).offset(8)
                     $0.centerY.equalTo(nameLabel)
                     $0.trailing.lessThanOrEqualTo(profileStatus.snp.leading).offset(-8)
                 } else {
-                    // 유저 + 시계 OFF → 이름 아래
+                  
                     $0.leading.equalTo(nameLabel)
                     $0.top.equalTo(nameLabel.snp.bottom).offset(4)
                     $0.trailing.lessThanOrEqualTo(profileStatus.snp.leading).offset(-8)

--- a/Projects/Feature/Sources/Scene/Main/View/MainProfileView.swift
+++ b/Projects/Feature/Sources/Scene/Main/View/MainProfileView.swift
@@ -15,7 +15,8 @@ public final class MainProfileView: UIView {
     
     var isClockOn: Bool = UserDefaults.standard.bool(forKey: "isClockOn") {
             didSet {
-                setLayout()
+                timeLabel.isHidden = !isClockOn
+                timeLabel.alpha = 0.6
             }
         }
     
@@ -34,7 +35,7 @@ public final class MainProfileView: UIView {
     
     let nameLabel = UILabel().then {
         $0.textColor = .color.mainText.color
-        $0.font = UIFont.suit(size: 18, weight: .semibold)
+        $0.font = UIFont.suit(size: 20, weight: .bold)
     }
     
     let studentInformationLabel = UILabel().then {
@@ -48,6 +49,14 @@ public final class MainProfileView: UIView {
         $0.font = UIFont.suit(size: 16, weight: .semibold)
     }
     
+    let timeLabel = UILabel().then {
+        $0.textColor = .color.sub2.color
+        $0.font = UIFont.suit(size: 24, weight: .heavy)
+        $0.isHidden = true
+    }
+
+    private var timer: Timer?
+    
     
     // MARK: - Initializer
     override init(frame: CGRect) {
@@ -55,6 +64,7 @@ public final class MainProfileView: UIView {
         configureUI()
         addView()
         setLayout()
+        startClock()
     }
     
     required init?(coder: NSCoder) {
@@ -70,36 +80,57 @@ public final class MainProfileView: UIView {
     
     // MARK: - Add View
     private func addView() {
-        [profileImageView, nameLabel, studentInformationLabel, lateCountLabel, profileStatus].forEach { self.addSubview($0) }
+        [nameLabel, studentInformationLabel, lateCountLabel, profileStatus, timeLabel].forEach { self.addSubview($0) }
     }
     
     // MARK: - Layout
     private func setLayout() {
-        profileImageView.snp.makeConstraints {
-            $0.width.height.equalTo(52)
-            $0.leading.equalToSuperview().inset(16)
-            $0.top.equalToSuperview().inset(20)
+        
+
+        nameLabel.snp.remakeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalToSuperview().inset(16)
         }
 
-        nameLabel.snp.makeConstraints {
-            $0.leading.equalTo(profileImageView.snp.trailing).offset(20)
-            $0.top.equalToSuperview().inset(20)
-        }
-
-        studentInformationLabel.snp.makeConstraints {
+        studentInformationLabel.snp.remakeConstraints {
             $0.leading.equalTo(nameLabel.snp.trailing).offset(8)
             $0.centerY.equalTo(nameLabel)
+            $0.trailing.lessThanOrEqualTo(profileStatus.snp.leading).offset(-8)
         }
 
-        lateCountLabel.snp.makeConstraints {
-            $0.leading.equalTo(nameLabel)
-            $0.top.equalTo(nameLabel.snp.bottom).offset(6)
-            $0.bottom.lessThanOrEqualToSuperview().inset(20)
+        lateCountLabel.snp.remakeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.trailing.lessThanOrEqualToSuperview().inset(16)
+            $0.top.equalTo(nameLabel.snp.bottom).offset(4)
         }
 
-        profileStatus.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
+        profileStatus.snp.remakeConstraints {
+            $0.top.equalToSuperview().inset(16)
             $0.trailing.equalToSuperview().inset(16)
         }
+
+        timeLabel.snp.remakeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.top.equalTo(profileStatus.snp.bottom).offset(2)
+        }
+
+    
+        timeLabel.isHidden = !isClockOn
+        
+    }
+
+    private func startClock() {
+        timer?.invalidate()
+
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            let formatter = DateFormatter()
+            formatter.dateFormat = "a h : mm : ss"
+            formatter.locale = Locale(identifier: "en_US")
+            self?.timeLabel.text = formatter.string(from: Date())
+        }
+    }
+
+    deinit {
+        timer?.invalidate()
     }
 }

--- a/Projects/Feature/Sources/Scene/Main/View/ProfileCardView.swift
+++ b/Projects/Feature/Sources/Scene/Main/View/ProfileCardView.swift
@@ -125,13 +125,15 @@ final class ProfileCardView: UIView {
         }
         
         studentInformationLabel.snp.makeConstraints {
-            $0.leading.equalTo(nameLabel)
-            $0.top.equalTo(nameLabel.snp.bottom).offset(4)
+            $0.leading.equalTo(nameLabel.snp.trailing).offset(8)
+            $0.centerY.equalTo(nameLabel)
+            $0.trailing.lessThanOrEqualTo(myOutingStatusLabel.snp.leading).offset(-8)
         }
         
         lateCountLabel.snp.makeConstraints {
             $0.leading.equalTo(nameLabel)
             $0.top.equalTo(nameLabel.snp.bottom).offset(6)
+            $0.trailing.lessThanOrEqualToSuperview().inset(16)
             $0.bottom.lessThanOrEqualToSuperview().inset(20)
         }
         

--- a/Projects/Feature/Sources/Scene/Main/View/ProfileCardView.swift
+++ b/Projects/Feature/Sources/Scene/Main/View/ProfileCardView.swift
@@ -15,7 +15,7 @@ final class ProfileCardView: UIView {
     
     var isClockOn: Bool = UserDefaults.standard.bool(forKey: "isClockOn") {
         didSet {
-            setLayout()
+            updateStudentInfoLayout()
         }
     }
     
@@ -45,6 +45,13 @@ final class ProfileCardView: UIView {
         $0.font = UIFont.suit(size: 15, weight: .medium)
     }
 
+    let subInfoLabel = UILabel().then {
+        $0.text = ""
+        $0.textColor = .color.sub1.color
+        $0.font = UIFont.suit(size: 15, weight: .medium)
+        $0.isHidden = true
+    }
+
     let myOutingStatusLabel = UILabel().then {
         $0.text = ""
         $0.textColor = .color.sub1.color
@@ -56,35 +63,35 @@ final class ProfileCardView: UIView {
                    lateCount: Int,
                    outingStatus: String,
                    isAdmin: Bool) {
-        
         nameLabel.text = name
         studentInformationLabel.text = studentInfo
-        
+        // 기본은 보이게
+        studentInformationLabel.isHidden = false
+
         if isAdmin {
-          
+            // ❗️ Admin에서는 중복 방지: 기본 라벨 숨기고 subInfo만 사용
+            studentInformationLabel.isHidden = true
             lateCountLabel.isHidden = true
-            
+            subInfoLabel.isHidden = false
+            subInfoLabel.text = studentInfo
+
             myOutingStatusLabel.text = "관리자"
             myOutingStatusLabel.textColor = .color.admin.color
-        
-            myOutingStatusLabel.snp.remakeConstraints {
-                $0.leading.equalTo(profileImageView.snp.trailing).offset(20)
-                $0.top.equalTo(studentInformationLabel.snp.bottom).offset(6)
-            }
-            
         } else {
-         
+            // ❗️ User에서는 기본 라벨 사용
+            studentInformationLabel.isHidden = false
+            studentInformationLabel.text = studentInfo
             lateCountLabel.isHidden = false
+            subInfoLabel.isHidden = true
             lateCountLabel.text = "지각 횟수: \(lateCount)회"
-            
+
             myOutingStatusLabel.text = outingStatus
             myOutingStatusLabel.textColor = .color.sub1.color
-            
-       
-            myOutingStatusLabel.snp.remakeConstraints {
-                $0.centerY.equalToSuperview()
-                $0.trailing.equalToSuperview().inset(16)
-            }
+        }
+
+        myOutingStatusLabel.snp.remakeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(16)
         }
     }
     
@@ -100,6 +107,7 @@ final class ProfileCardView: UIView {
         addView()
         setLayout()
         configureUI()
+        updateStudentInfoLayout()
     }
 
     required init?(coder: NSCoder) {
@@ -108,7 +116,7 @@ final class ProfileCardView: UIView {
     
     // MARK: - Add View
     private func addView() {
-        [profileImageView, nameLabel, studentInformationLabel, lateCountLabel, myOutingStatusLabel].forEach { self.addSubview($0) }
+        [profileImageView, nameLabel, studentInformationLabel, lateCountLabel, subInfoLabel, myOutingStatusLabel].forEach { self.addSubview($0) }
     }
     
     // MARK: - Layout
@@ -118,29 +126,35 @@ final class ProfileCardView: UIView {
             $0.leading.equalToSuperview().inset(16)
             $0.top.equalToSuperview().inset(20)
         }
-        
+
         nameLabel.snp.makeConstraints {
             $0.leading.equalTo(profileImageView.snp.trailing).offset(20)
             $0.top.equalToSuperview().inset(20)
         }
-        
-        studentInformationLabel.snp.makeConstraints {
-            $0.leading.equalTo(nameLabel.snp.trailing).offset(8)
-            $0.centerY.equalTo(nameLabel)
-            $0.trailing.lessThanOrEqualTo(myOutingStatusLabel.snp.leading).offset(-8)
-        }
-        
+
         lateCountLabel.snp.makeConstraints {
             $0.leading.equalTo(nameLabel)
             $0.top.equalTo(nameLabel.snp.bottom).offset(6)
             $0.trailing.lessThanOrEqualToSuperview().inset(16)
             $0.bottom.lessThanOrEqualToSuperview().inset(20)
         }
-        
+
+        subInfoLabel.snp.makeConstraints {
+            $0.leading.equalTo(nameLabel)
+            $0.top.equalTo(nameLabel.snp.bottom).offset(6)
+        }
+
         myOutingStatusLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(16)
         }
- 
+    }
+
+    private func updateStudentInfoLayout() {
+        studentInformationLabel.snp.remakeConstraints {
+            $0.leading.equalTo(nameLabel.snp.trailing).offset(8)
+            $0.centerY.equalTo(nameLabel)
+            $0.trailing.lessThanOrEqualTo(myOutingStatusLabel.snp.leading).offset(-8)
+        }
     }
 }

--- a/Projects/Feature/Sources/Scene/Main/View/ProfileCardView.swift
+++ b/Projects/Feature/Sources/Scene/Main/View/ProfileCardView.swift
@@ -69,7 +69,7 @@ final class ProfileCardView: UIView {
         studentInformationLabel.isHidden = false
 
         if isAdmin {
-            // ❗️ Admin에서는 중복 방지: 기본 라벨 숨기고 subInfo만 사용
+           
             studentInformationLabel.isHidden = true
             lateCountLabel.isHidden = true
             subInfoLabel.isHidden = false
@@ -78,7 +78,7 @@ final class ProfileCardView: UIView {
             myOutingStatusLabel.text = "관리자"
             myOutingStatusLabel.textColor = .color.admin.color
         } else {
-            // ❗️ User에서는 기본 라벨 사용
+        
             studentInformationLabel.isHidden = false
             studentInformationLabel.text = studentInfo
             lateCountLabel.isHidden = false

--- a/Projects/Feature/Sources/Scene/Main/ViewModel/MainViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Main/ViewModel/MainViewModel.swift
@@ -122,7 +122,7 @@ public final class MainViewModel: BaseViewModel {
     func getProfile(completion: @escaping (String?) -> Void) {
         if isTestMode {
             self.profileData = ProfileData(profileUrl: nil,
-                                           name: "테스트 사용자",
+                                           name: "김준표",
                                            grade: 3,
                                            major: "SW",
                                            authority: "ROLE_STUDENT",

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
@@ -66,13 +66,13 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
     }
     
     let userName = UILabel().then {
-        $0.text = "테스트 사용자"
+        $0.text = "김준표"
         $0.textColor = .color.mainText.color
         $0.font = .suit(size: 18, weight: .bold)
     }
     
     let userGradeDepartment = UILabel().then {
-        $0.text = "3기 | AI"
+        $0.text = "9기 | IoT"
         $0.textColor = .color.sub2.color
         $0.font = .suit(size: 14, weight: .medium)
     }

--- a/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
@@ -46,13 +46,13 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
     }
     
     let userName = UILabel().then {
-        $0.text = "테스트 사용자"
+        $0.text = "김준표"
         $0.textColor = .color.mainText.color
         $0.font = .suit(size: 18, weight: .bold)
     }
     
     let userGradeDepartment = UILabel().then {
-        $0.text = "3기 | AI"
+        $0.text = "9기 | IoT"
         $0.textColor = .color.sub2.color
         $0.font = .suit(size: 14, weight: .medium)
     }
@@ -217,15 +217,11 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
     }
     
     @objc func switchClockOn(_ sender: UISwitch) {
+       
         UserDefaults.standard.set(sender.isOn, forKey: "isClockOn")
-        
-        let defaults = UserDefaults.standard
-        
-        let isClockOn = defaults.bool(forKey: "isClockOn")
-        
-        if let mainViewController = navigationController?.viewControllers.first(where: { $0 is MainViewController }) as? MainViewController {
-            mainViewController.isClockOn = sender.isOn
-        }
+
+   
+        NotificationCenter.default.post(name: Notification.Name("clockChanged"), object: nil)
     }
     
     @IBAction private func ShowActionSheetClick(_ sender: UIButton) {


### PR DESCRIPTION
# 🍎 개요
프로필 뷰에서 발생하던 텍스트 겹침 및 레이아웃 이슈를 해결하고,  
시계 표시 상태 isClockOn에 따른 UI 분기 처리 적용

# 📦 작업 내용
- User ProfileCard에 시계 표시 기능 바인딩 추가
- 프로필 뷰 텍스트 겹침 문제 해결
- 지각 횟수 레이아웃 이슈 수정
- 프로필 및 외출 상태 UI 테스트용 더미 데이터 추가
