### PR TITLE
🔀 :: #92 Auth API Service 구현 및 DTO 구성

### DIFF
--- a/Projects/Service/Sources/Request/Auth/AuthNumber/SendAuthCodeRequest.swift
+++ b/Projects/Service/Sources/Request/Auth/AuthNumber/SendAuthCodeRequest.swift
@@ -1,8 +1,8 @@
 //
-//  SendAuthNumberRequest.swift
+//  SendAuthCodeRequest.swift
 //  Service
 //
-//  Created by 김준표 on 2/24/26.
+//  Created by 김준표 on 3/27/26.
 //  Copyright © 2026 HARIBO. All rights reserved.
 //
 
@@ -10,10 +10,10 @@ import Foundation
 
 public struct SendAuthCodeRequest: Codable {
     var email: String
-    var emailStatus: String
+    var purpose: String
     
-    public init(email: String, emailStatus: String) {
+    public init(email: String, purpose: String) {
         self.email = email
-        self.emailStatus = emailStatus
+        self.purpose = purpose
     }
 }

--- a/Projects/Service/Sources/Request/Auth/AuthNumber/VerifyAuthNumberRequest.swift
+++ b/Projects/Service/Sources/Request/Auth/AuthNumber/VerifyAuthNumberRequest.swift
@@ -1,8 +1,0 @@
-//
-//  VerifyAuthNumberRequest.swift
-//  Service
-//
-//  Created by 김준표 on 2/24/26.
-//  Copyright © 2026 HARIBO. All rights reserved.
-//
-

--- a/Projects/Service/Sources/Services/Auth/AuthServices.swift
+++ b/Projects/Service/Sources/Services/Auth/AuthServices.swift
@@ -14,7 +14,7 @@ public enum AuthServices {
     case signIn(param: SignInRequest)
     case refreshToken(refreshToken: String)
     case sendAuthCode(param: SendAuthCodeRequest)
-    case verifyAuthNumber(email: String, authCode: String)
+    case verifyAuthNumber(email: String, code: String)
     case logoutToken(refreshToken: String)
 }
 
@@ -25,7 +25,7 @@ extension AuthServices: TargetType {
             let urlString = Bundle.main.infoDictionary?["SchoolBaseURL"] as? String,
             let url = URL(string: urlString)
         else {
-            fatalError("AuthAPIㅣURL을 불러올 수 없습니다.")
+            fatalError("AuthAPI URL을 불러올 수 없습니다.")
         }
         return url
     }
@@ -56,14 +56,12 @@ extension AuthServices: TargetType {
         switch self {
         case .signUp,
              .signIn,
-             .sendAuthCode:
+             .sendAuthCode,
+             .verifyAuthNumber:
             return .post
 
         case .refreshToken:
             return .patch
-
-        case .verifyAuthNumber:
-            return .get
 
         case .logoutToken:
             return .delete
@@ -88,20 +86,15 @@ extension AuthServices: TargetType {
         case .refreshToken:
             return .requestPlain
 
-        case let .verifyAuthNumber(email, authCode):
-            return .requestParameters(
-                parameters: [
-                    "email": email,
-                    "authCode": authCode
-                ],
-                encoding: URLEncoding.queryString
-            )
+        case let .verifyAuthNumber(email, code):
+            return .requestJSONEncodable([
+                "email": email,
+                "code": code,
+                "purpose": "SIGNUP"
+            ])
 
-        case let .logoutToken(refreshToken):
-            return .requestParameters(
-                parameters: ["refreshToken": refreshToken],
-                encoding: JSONEncoding.default
-            )
+        case .logoutToken:
+            return .requestPlain
         }
     }
 
@@ -111,7 +104,7 @@ extension AuthServices: TargetType {
              let .logoutToken(refreshToken):
             return [
                 "Content-Type": "application/json",
-                "refreshToken": refreshToken
+                "RefreshToken": "Bearer \(refreshToken)"
             ]
 
         default:
@@ -121,3 +114,4 @@ extension AuthServices: TargetType {
         }
     }
 }
+


### PR DESCRIPTION
# 🍎 개요
Auth 관련 API(Service)와 DTO를 구성하여 회원가입 및 인증 흐름을 구현했습니다

# 📦 작업 내용
- AuthServices 구현
- 회원가입 (/signup)
- 로그인 (/signin)
- 토큰 재발급 (/reissue)
- 인증번호 발송 (/email-verifications/send)
- 인증번호 확인 (/email-verifications/confirm)
- 로그아웃 (/signout)

- DTO 구성 및 수정
- SignUpRequest DTO 명세에 맞게 수정
- SendAuthCodeRequest DTO 추가
- enum(Gender, Major) 적용
- API 명세 기반 수정
- verifyAuthNumber → POST + JSON body 적용
- RefreshToken header 적용 (Bearer)
- requestPlain / requestJSONEncodable 구분 적용


