### PR TITLE
🔀 :: #95 AuthViewModel 구현 및 회원가입 인증 흐름 연결

### DIFF
--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -16,17 +16,15 @@ public final class AuthViewModel: BaseViewModel {
 
     public override init() {}
 
-    // MARK: - Properties
     private var email: String = ""
     private var password: String = ""
     private var authCode: String = ""
     private var verifiedToken: String = ""
     private var name: String = ""
 
-    private var gender: Gender = .man
+    private var gender: Gender = .male
     private var major: Major = .sw
 
-    // MARK: - Setup
     func setupEmail(email: String) {
         self.email = email
     }
@@ -51,9 +49,7 @@ public final class AuthViewModel: BaseViewModel {
         self.major = major
     }
 
-    // MARK: - 인증번호 발송
     func sendAuthCode(completion: @escaping (Bool, Int) -> Void) {
-
         let param = SendAuthCodeRequest(
             email: email,
             purpose: "SIGNUP"
@@ -61,7 +57,6 @@ public final class AuthViewModel: BaseViewModel {
 
         authProvider.request(.sendAuthCode(param: param)) { response in
             switch response {
-
             case .success(let result):
                 completion((200..<300).contains(result.statusCode), result.statusCode)
 
@@ -71,27 +66,20 @@ public final class AuthViewModel: BaseViewModel {
         }
     }
 
-    // MARK: - 인증번호 확인
     func verifyAuthCode(completion: @escaping (Bool) -> Void) {
-
         authProvider.request(.verifyAuthNumber(email: email, code: authCode)) { response in
             switch response {
-
             case .success(let result):
+                guard (200..<300).contains(result.statusCode) else {
+                    completion(false)
+                    return
+                }
 
-                if (200..<300).contains(result.statusCode) {
-                    do {
-                        let data = try result.map(VerifyAuthResponse.self)
-
-                       
-                        self.verifiedToken = data.verifiedToken
-
-                        completion(true)
-                    } catch {
-                        completion(false)
-                    }
-
-                } else {
+                do {
+                    let data = try result.map(VerifyAuthResponse.self)
+                    self.verifiedToken = data.verifiedToken
+                    completion(true)
+                } catch {
                     completion(false)
                 }
 
@@ -101,8 +89,11 @@ public final class AuthViewModel: BaseViewModel {
         }
     }
 
-    // MARK: - 회원가입
     func signUp(completion: @escaping (Bool) -> Void) {
+        guard !verifiedToken.isEmpty else {
+            completion(false)
+            return
+        }
 
         let param = SignUpRequest(
             email: email,
@@ -116,7 +107,6 @@ public final class AuthViewModel: BaseViewModel {
 
         authProvider.request(.signUp(param: param)) { response in
             switch response {
-
             case .success(let result):
                 completion(result.statusCode == 201)
 

--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -16,6 +16,7 @@ public final class AuthViewModel: BaseViewModel {
 
     public override init() {}
 
+    // MARK: - Properties
     private var email: String = ""
     private var password: String = ""
     private var authCode: String = ""
@@ -25,6 +26,7 @@ public final class AuthViewModel: BaseViewModel {
     private var gender: Gender = .male
     private var major: Major = .sw
 
+    // MARK: - Setup
     func setupEmail(email: String) {
         self.email = email
     }
@@ -49,7 +51,9 @@ public final class AuthViewModel: BaseViewModel {
         self.major = major
     }
 
+    // MARK: - 인증번호 발송
     func sendAuthCode(completion: @escaping (Bool, Int) -> Void) {
+
         let param = SendAuthCodeRequest(
             email: email,
             purpose: "SIGNUP"
@@ -57,40 +61,55 @@ public final class AuthViewModel: BaseViewModel {
 
         authProvider.request(.sendAuthCode(param: param)) { response in
             switch response {
+
             case .success(let result):
                 completion((200..<300).contains(result.statusCode), result.statusCode)
 
-            case .failure:
+            case .failure(let error):
+                print("인증번호 발송 실패: \(error.localizedDescription)")
                 completion(false, 0)
             }
         }
     }
 
+    // MARK: - 인증번호 확인
     func verifyAuthCode(completion: @escaping (Bool) -> Void) {
+
         authProvider.request(.verifyAuthNumber(email: email, code: authCode)) { response in
             switch response {
+
             case .success(let result):
+
                 guard (200..<300).contains(result.statusCode) else {
+                    print("인증번호 검증 실패: statusCode = \(result.statusCode)")
                     completion(false)
                     return
                 }
 
                 do {
                     let data = try result.map(VerifyAuthResponse.self)
+
                     self.verifiedToken = data.verifiedToken
+
                     completion(true)
+
                 } catch {
+                    print("VerifyAuthResponse 디코딩 실패: \(error.localizedDescription)")
                     completion(false)
                 }
 
-            case .failure:
+            case .failure(let error):
+                print("인증번호 검증 네트워크 실패: \(error.localizedDescription)")
                 completion(false)
             }
         }
     }
 
+    // MARK: - 회원가입
     func signUp(completion: @escaping (Bool) -> Void) {
+
         guard !verifiedToken.isEmpty else {
+            print("회원가입 실패: 인증 토큰 없음 (verifyAuthCode 먼저 수행 필요)")
             completion(false)
             return
         }
@@ -107,10 +126,12 @@ public final class AuthViewModel: BaseViewModel {
 
         authProvider.request(.signUp(param: param)) { response in
             switch response {
+
             case .success(let result):
                 completion(result.statusCode == 201)
 
-            case .failure:
+            case .failure(let error):
+                print("회원가입 네트워크 실패: \(error.localizedDescription)")
                 completion(false)
             }
         }

--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -13,32 +13,22 @@ import Foundation
 public final class AuthViewModel: BaseViewModel {
 
     private let authProvider = MoyaProvider<AuthServices>()
-    private let accountProvider = MoyaProvider<AccountServices>()
 
     public override init() {}
 
-    var userData: SignInModel?
-
-    public let profileModel = ProfileViewModel()
-    public let notificationViewModel = NotificationViewModel()
-
+    // MARK: - Properties
     private var email: String = ""
     private var password: String = ""
     private var authCode: String = ""
-    private var newPassword: String = ""
-    private var newServePassword: String = ""
+    private var verifiedToken: String = ""
     private var name: String = ""
-    private var gender: String = ""
-    private var major: String = ""
-    private var emailStatus: String = ""
-    private var passwordServe: String = ""
 
-    func setupEmailStatus(emailStatus: String) {
-        self.emailStatus = emailStatus
-    }
+    private var gender: Gender = .man
+    private var major: Major = .sw
 
+    // MARK: - Setup
     func setupEmail(email: String) {
-        self.email = "\(email)@gsm.hs.kr"
+        self.email = email
     }
 
     func setupPassword(password: String) {
@@ -49,244 +39,88 @@ public final class AuthViewModel: BaseViewModel {
         self.authCode = authCode
     }
 
-    func setupNewPassword(newPassword: String, checkPassword: String) {
-        guard newPassword == checkPassword else { return }
-        self.newPassword = newPassword
-    }
-
-    func setupNewServePassword(newPassword: String, checkPassword: String) {
-        guard newPassword == checkPassword else { return }
-        self.newServePassword = newPassword
-    }
-
     func setupName(name: String) {
         self.name = name
     }
 
-    func setupGender(gender: String) {
+    func setupGender(gender: Gender) {
         self.gender = gender
     }
 
-    func setupMajor(major: String) {
+    func setupMajor(major: Major) {
         self.major = major
     }
 
-    func signIn(completion: @escaping (Int, String?) -> Void) {
-
-        let param = SignInRequest(email: email, password: password)
-
-        authProvider.request(.signIn(param: param)) { [weak self] response in
-            guard let self = self else { return }
-
-            DispatchQueue.global().async {
-
-                var authority: String? = nil
-                var statusCode = 0
-
-                switch response {
-
-                case .success(let result):
-
-                    statusCode = result.statusCode
-
-                    do {
-                        switch statusCode {
-
-                        case 200:
-
-                            let signInResponse = try result.map(SignInResponse.self)
-
-                            self.keyChain.create(key: Const.KeyChainKey.accessToken, token: signInResponse.accessToken)
-                            self.keyChain.create(key: Const.KeyChainKey.refreshToken, token: signInResponse.refreshToken)
-                            self.keyChain.create(key: Const.KeyChainKey.authority, token: signInResponse.authority)
-
-                            authority = signInResponse.authority
-
-                            if let savedToken = UserDefaults.standard.string(forKey: "FCMToken"),
-                               let accessToken = KeyChain.shared.read(key: Const.KeyChainKey.accessToken) {
-
-                                self.notificationViewModel.setupFcmToken(fcmToken: savedToken)
-                                self.notificationViewModel.setupaccessToken(accessToken: accessToken)
-
-                                self.notificationViewModel.postFcmToken { success in
-                                    if success {
-                                        print("FCM 토큰 전송 성공")
-                                    } else {
-                                        print("FCM 토큰 전송 실패")
-                                    }
-                                }
-                            }
-
-                        default:
-                            break
-                        }
-
-                    } catch {
-                        print("Error parsing SignInResponse: \(error)")
-                    }
-
-                case .failure(let err):
-                    print("Network error: \(err.localizedDescription)")
-                }
-
-                DispatchQueue.main.async {
-                    completion(statusCode, authority)
-                }
-            }
-        }
-    }
-
+    // MARK: - 인증번호 발송
     func sendAuthCode(completion: @escaping (Bool, Int) -> Void) {
 
-        let param = SendAuthCodeRequest(email: email, emailStatus: emailStatus)
+        let param = SendAuthCodeRequest(
+            email: email,
+            purpose: "SIGNUP"
+        )
 
         authProvider.request(.sendAuthCode(param: param)) { response in
-
             switch response {
 
             case .success(let result):
+                completion((200..<300).contains(result.statusCode), result.statusCode)
 
-                let statusCode = result.statusCode
-
-                switch statusCode {
-
-                case 204:
-                    completion(true, statusCode)
-
-                case 404, 429:
-                    completion(false, statusCode)
-
-                default:
-                    completion(false, statusCode)
-                }
-
-            case .failure(let err):
-                print(err.localizedDescription)
+            case .failure:
                 completion(false, 0)
             }
         }
     }
 
+    // MARK: - 인증번호 확인
     func verifyAuthCode(completion: @escaping (Bool) -> Void) {
 
-        authProvider.request(.verifyAuthNumber(email: email, authCode: authCode)) { response in
-
+        authProvider.request(.verifyAuthNumber(email: email, code: authCode)) { response in
             switch response {
 
             case .success(let result):
 
-                let statusCode = result.statusCode
+                if (200..<300).contains(result.statusCode) {
+                    do {
+                        let data = try result.map(VerifyAuthResponse.self)
 
-                switch statusCode {
+                       
+                        self.verifiedToken = data.verifiedToken
 
-                case 200..<300:
-                    completion(true)
+                        completion(true)
+                    } catch {
+                        completion(false)
+                    }
 
-                case 401, 404, 429, 500:
-                    completion(false)
-
-                default:
+                } else {
                     completion(false)
                 }
 
-            case .failure(let err):
-                print(err.localizedDescription)
+            case .failure:
                 completion(false)
             }
         }
     }
 
-    func newPassword(completion: @escaping (Bool, Int) -> Void) {
-
-        let param = NewPasswordRequest(email: email, newPassword: newServePassword)
-
-        accountProvider.request(.newPassword(param: param)) { response in
-
-            switch response {
-
-            case .success(let result):
-
-                let statusCode = result.statusCode
-
-                switch statusCode {
-
-                case 204:
-                    completion(true, statusCode)
-
-                case 400, 404, 500:
-                    completion(false, statusCode)
-
-                default:
-                    completion(false, statusCode)
-                }
-
-            case .failure(let err):
-                print(err.localizedDescription)
-            }
-        }
-    }
-
-    func changNewPassword(completion: @escaping (Bool, Int) -> Void) {
-
-        let param = ChangPasswordRequest(password: password, newPassword: newPassword)
-
-        accountProvider.request(.changPassword(param: param, authorization: accessToken)) { response in
-
-            switch response {
-
-            case .success(let result):
-
-                let statusCode = result.statusCode
-
-                switch statusCode {
-
-                case 204:
-                    completion(true, statusCode)
-
-                case 400, 404, 500:
-                    completion(false, statusCode)
-
-                default:
-                    completion(false, statusCode)
-                }
-
-            case .failure(let err):
-                print(err.localizedDescription)
-                completion(false, 0)
-            }
-        }
-    }
-
+    // MARK: - 회원가입
     func signUp(completion: @escaping (Bool) -> Void) {
 
         let param = SignUpRequest(
             email: email,
-            password: newPassword,
+            verifiedToken: verifiedToken,
+            password: password,
             name: name,
-            gender: gender,
-            major: major
+            grade: 1,
+            department: major,
+            gender: gender
         )
 
         authProvider.request(.signUp(param: param)) { response in
-
             switch response {
 
             case .success(let result):
+                completion(result.statusCode == 201)
 
-                switch result.statusCode {
-
-                case 201:
-                    completion(true)
-
-                case 500:
-                    completion(false)
-
-                default:
-                    completion(false)
-                }
-
-            case .failure(let err):
-                print(err.localizedDescription)
+            case .failure:
                 completion(false)
             }
         }

--- a/Projects/Service/Sources/Model/Auth/VerifyAuth/VerifyAuthResponse.swift
+++ b/Projects/Service/Sources/Model/Auth/VerifyAuth/VerifyAuthResponse.swift
@@ -1,0 +1,22 @@
+//
+//  VerifyAuthResponse.swift
+//  Service
+//
+//  Created by 김준표 on 3/27/26.
+//  Copyright © 2026 HARIBO. All rights reserved.
+//
+
+import Foundation
+
+public struct VerifyAuthResponse: Codable {
+    public let verifiedToken: String
+    public let verifiedTokenExpiresIn: String
+
+    public init(
+        verifiedToken: String,
+        verifiedTokenExpiresIn: String
+    ) {
+        self.verifiedToken = verifiedToken
+        self.verifiedTokenExpiresIn = verifiedTokenExpiresIn
+    }
+}

--- a/Projects/Service/Sources/Request/Auth/AuthNumber/SendAuthCodeRequest.swift
+++ b/Projects/Service/Sources/Request/Auth/AuthNumber/SendAuthCodeRequest.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 public struct SendAuthCodeRequest: Codable {
-    var email: String
-    var purpose: String
-    
+    let email: String
+    let purpose: String
+
     public init(email: String, purpose: String) {
         self.email = email
         self.purpose = purpose

--- a/Projects/Service/Sources/Request/Auth/SignUp/SignUpRequest.swift
+++ b/Projects/Service/Sources/Request/Auth/SignUp/SignUpRequest.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 public struct SignUpRequest: Codable {
-    var email: String
-    var verifiedToken: String
-    var password: String
-    var name: String
-    var grade: Int
-    var department: Major
-    var gender: Gender
-    
+    let email: String
+    let verifiedToken: String
+    let password: String
+    let name: String
+    let grade: Int
+    let department: Major
+    let gender: Gender
+
     public init(
         email: String,
         verifiedToken: String,


### PR DESCRIPTION
# 🍎 개요
회원가입 인증 흐름을 ViewModel에 연결하고, 인증번호 검증 후 회원가입까지 이어지는 로직을 구현했습니다

# 📦 작업 내용
1. DTO 추가
- VerifyAuthResponse DTO 추가
- 인증번호 검증 응답에서 verifiedToken 파싱 가능하도록 구성

2. AuthViewModel 구현
- 이메일 인증번호 발송 API 연결
- 인증번호 검증 API 연결
- 인증 성공 시 verifiedToken 저장
- 회원가입 시 verifiedToken 사용하도록 수정

3. 흐름 구성
- sendAuthCode → verifyAuthCode → signUp 흐름 완성

