### PR TITLE
🔀 :: #101 로그인 API 서버 연동 및 에러 처리 로직 구현

### DIFF
--- a/Projects/Feature/Sources/Extension/GOMSRefreshToken.swift
+++ b/Projects/Feature/Sources/Extension/GOMSRefreshToken.swift
@@ -79,12 +79,7 @@ public final class GOMSRefreshToken {
             key: Const.KeyChainKey.refreshToken
         )
 
-        let authorityUpdated = keychain.updateItem(
-            token: reissuanceData?.authority ?? "",
-            key: Const.KeyChainKey.authority
-        )
-
-        if accessTokenUpdated && refreshTokenUpdated && authorityUpdated {
+        if accessTokenUpdated && refreshTokenUpdated {
             print("keychain update success")
         } else {
             print("keychain update failed")

--- a/Projects/Feature/Sources/Scene/Auth/SignIn/SignInViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/SignIn/SignInViewController.swift
@@ -137,40 +137,56 @@ public final class SignInViewController: BaseViewController {
         let emailRegex = "^s[0-9]{5}$"
         let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
 
-        // 더미 계정(admin/user)은 이메일 형식 검증 예외 처리
-        if email != "admin" && email != "user" {
-            if !emailPredicate.evaluate(with: email) {
-                emailErrorLabel.text = "올바른 이메일 형식이 아닙니다."
-                showEmailError()
-                return
-            }
+        if !emailPredicate.evaluate(with: email) {
+            emailErrorLabel.text = "올바른 이메일 형식이 아닙니다."
+            showEmailError()
+            return
         }
 
-        //  비밀번호 일치 여부 체크
-        if password != "1234" {
-            passwordErrorLabel.text = "비밀번호가 일치하지 않습니다."
+        if password.isEmpty {
+            passwordErrorLabel.text = "비밀번호를 입력해주세요."
             showPasswordError()
             return
         }
 
-      
-        UserDefaults.standard.set("dummyToken", forKey: "accessToken")
-        UserDefaults.standard.set("dummyRefresh", forKey: "refreshToken")
-        UserDefaults.standard.set(email, forKey: "localEmail")
-        UserDefaults.standard.set(password, forKey: "localPass")
+        // MARK: - 실제 로그인 API 호출
+        viewModel.setupEmail(email: email)
+        viewModel.setupPassword(password: password)
 
-        // 더미 계정 분기 처리
-        if email == "admin" && password == "1234" {
-            let adminVC = AdminMainViewController()
-            self.navigationController?.setViewControllers([adminVC], animated: false)
-        } else if email == "user" && password == "1234" {
-            let userVC = MainViewController()
-            self.navigationController?.setViewControllers([userVC], animated: false)
-        } else {
-            passwordErrorLabel.text = "계정을 확인해주세요."
-            showPasswordError()
+        viewModel.signIn { [weak self] statusCode, authority in
+            guard let self = self else { return }
+            print("STATUS:", statusCode)
+
+            DispatchQueue.main.async {
+                if (200..<300).contains(statusCode) {
+                    
+                    UserDefaults.standard.set(email, forKey: "localEmail")
+                    UserDefaults.standard.set(password, forKey: "localPass")
+                    
+                    if authority == "ROLE_STUDENT" {
+                        let mainVC = MainViewController()
+                        self.navigationController?.setViewControllers([mainVC], animated: true)
+                        
+                    } else if authority == "ROLE_STUDENT_COUNCIL" {
+                        let adminVC = AdminMainViewController()
+                        self.navigationController?.setViewControllers([adminVC], animated: true)
+                        
+                    } else {
+                        self.passwordErrorLabel.text = "권한 정보를 확인할 수 없습니다."
+                        self.showPasswordError()
+                    }
+
+                } else if statusCode == 400 || statusCode == 403 || statusCode == 404 {
+                    self.passwordErrorLabel.text = "이메일 또는 비밀번호를 확인해주세요."
+                    self.showPasswordError()
+                    
+                } else {
+                    self.passwordErrorLabel.text = "서버 오류가 발생했습니다."
+                    self.showPasswordError()
+                }
+                
+            }
         }
-        return
     }
 
     @objc func showPasswordButtonTapped() {
@@ -375,9 +391,6 @@ extension SignInViewController: UITextFieldDelegate {
                     $0.height.equalTo(0)
                 }
                 view.layoutIfNeeded()
-            } else if email == "admin" || email == "user" {
-                // 더미 계정은 형식 검사 통과
-                showDefaultState()
             } else if !emailPredicate.evaluate(with: email) {
                 emailErrorLabel.text = "올바른 이메일 형식이 아닙니다."
                 showEmailError()

--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -79,6 +79,8 @@ public final class AuthViewModel: BaseViewModel {
                 switch response {
 
                 case .success(let result):
+                    print("LOGIN RAW RESPONSE")
+                    print(String(data: result.data, encoding: .utf8) ?? "nil")
 
                     statusCode = result.statusCode
 
@@ -91,9 +93,17 @@ public final class AuthViewModel: BaseViewModel {
 
                             self.keyChain.create(key: Const.KeyChainKey.accessToken, token: signInResponse.accessToken)
                             self.keyChain.create(key: Const.KeyChainKey.refreshToken, token: signInResponse.refreshToken)
-                            self.keyChain.create(key: Const.KeyChainKey.authority, token: signInResponse.authority)
+                           
+                            let accessToken = signInResponse.accessToken
 
-                            authority = signInResponse.authority
+                            if let payload = accessToken.split(separator: ".").dropFirst().first,
+                               let data = Data(base64Encoded: String(payload) + "=="),
+                               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                               let role = json["role"] as? String {
+
+                                self.keyChain.create(key: Const.KeyChainKey.authority, token: role)
+                                authority = role
+                            }
 
                             if let savedToken = UserDefaults.standard.string(forKey: "FCMToken"),
                                let accessToken = KeyChain.shared.read(key: Const.KeyChainKey.accessToken) {

--- a/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/Admin/View/AdminMainViewController.swift
@@ -209,7 +209,7 @@ private let profileVC = AdminProfileViewController()
         authViewModel.setupEmail(email: isLocalEmail)
         authViewModel.setupPassword(password: isLocalPass)
 
-        authViewModel.signIn { [weak self] statusCode in
+        authViewModel.signIn { [weak self] statusCode, _ in
             guard let self = self else { return }
             DispatchQueue.main.async {
                 guard self.isVisible else {

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -304,7 +304,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
         authViewModel.setupPassword(password: isLocalPass)
         
         
-        authViewModel.signIn { [weak self] (statusCode: Int) in
+        authViewModel.signIn { [weak self] (statusCode: Int, _) in
             guard let self = self else { return }
             
             DispatchQueue.main.async {

--- a/Projects/Service/Sources/Model/Auth/SignIn/SignInModel.swift
+++ b/Projects/Service/Sources/Model/Auth/SignIn/SignInModel.swift
@@ -8,14 +8,9 @@
 
 import Foundation
 
-public struct SignInModel: Codable {
-    public let data: SignInResponse?
-}
-
 public struct SignInResponse: Codable {
     public let accessToken: String
     public let refreshToken: String
-    public let accessTokenExp: String
-    public let refreshTokenExp: String
-    public let authority: String
+    public let accessTokenExpiresIn: String
+    public let refreshTokenExpiresIn: String
 }


### PR DESCRIPTION
# 🍎 개요
로그인 화면에서 더미 계정 로직을 제거하고 실제 서버 기반 로그인으로 전환했습니다.
API 응답 상태코드에 따라 UI 에러 처리를 분기하도록 수정했습니다

# 📦 작업 내용
- 로그인 더미 계정 (admin, user) 완전 제거
-AuthViewModel.signIn 기반 실제 서버 통신 적용

로그인 성공 시:
-accessToken / refreshToken Keychain 저장
-localEmail / localPass UserDefaults 저장
-권한(authority)에 따른 화면 분기 처리
-ROLE_STUDENT → MainViewController
-ROLE_STUDENT_COUNCIL → AdminMainViewController

