### PR TITLE
🔀 :: #103 비밀번호 재설정 흐름 개선 및 API 연동

### DIFF
--- a/Projects/Feature/Sources/Scene/Auth/AuthCode/AuthCodeViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/AuthCode/AuthCodeViewController.swift
@@ -15,9 +15,10 @@ public final class AuthCodeViewController: BaseViewController {
     var email: String?
 
     private var limitTime = 300
+    private var isRequestingAuthCode = false
 
     private let pageTitleLabel = UILabel().then {
-        $0.text = "인증 번호"
+        $0.text = "인증번호"
         $0.font = .suit(size: 28, weight: .bold)
         $0.textColor = .color.mainText.color
     }
@@ -95,13 +96,54 @@ public final class AuthCodeViewController: BaseViewController {
     }
 
     @objc private func resendButtonTapped() {
-        let alert = UIAlertController(
-            title: "재발송 완료",
-            message:  "인증번호를 다시 보냈습니다.\n이메일을 확인해주세요.",
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-        self.present(alert, animated: true)
+        if isRequestingAuthCode { return }
+        isRequestingAuthCode = true
+        resendButton.isEnabled = false
+
+        guard let email = self.email else { return }
+        viewModel.setupEmail(email: email)
+        viewModel.sendAuthCode { [weak self] success, statusCode in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                if statusCode == 429 {
+                    self.isRequestingAuthCode = true
+                    self.resendButton.isEnabled = false
+                    
+                    let alert = UIAlertController(
+                        title: "요청 제한",
+                        message: "잠시 후 다시 시도해주세요.",
+                        preferredStyle: .alert
+                    )
+                    alert.addAction(UIAlertAction(title: "확인", style: .cancel))
+                    self.present(alert, animated: true)
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                        self.isRequestingAuthCode = false
+                        self.resendButton.isEnabled = true
+                    }
+                } else if success {
+                    self.isRequestingAuthCode = false
+                    self.resendButton.isEnabled = true
+                    let alert = UIAlertController(
+                        title: "재발송 완료",
+                        message: "인증번호를 다시 보냈습니다.\n이메일을 확인해주세요.",
+                        preferredStyle: .alert
+                    )
+                    alert.addAction(UIAlertAction(title: "확인", style: .cancel))
+                    self.present(alert, animated: true)
+                } else {
+                    self.isRequestingAuthCode = false
+                    self.resendButton.isEnabled = true
+                    let alert = UIAlertController(
+                        title: "오류",
+                        message: "인증번호 재발송에 실패했습니다.",
+                        preferredStyle: .alert
+                    )
+                    alert.addAction(UIAlertAction(title: "확인", style: .cancel))
+                    self.present(alert, animated: true)
+                }
+            }
+        }
     }
 
     @objc private func authButtonTapped() {

--- a/Projects/Feature/Sources/Scene/Auth/FindPassword/FindPasswordViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/FindPassword/FindPasswordViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 public final class FindPasswordViewController: BaseViewController {
 
     private var viewModel: AuthViewModel
+    private var isRequesting = false
     
     private let pageTitleLabel = UILabel().then {
         $0.text = "비밀번호 찾기"
@@ -68,12 +69,17 @@ public final class FindPasswordViewController: BaseViewController {
     }
 
     @objc private func authCodeButtonTapped() {
+        if isRequesting { return }
+        isRequesting = true
+        authCodeButton.isEnabled = false
 
         let email = emailTextField.text ?? ""
 
         if email.isEmpty {
             emailErrorLabel.text = "이메일을 입력해주세요."
             showEmailError()
+            authCodeButton.isEnabled = true
+            isRequesting = false
             return
         }
 
@@ -83,20 +89,62 @@ public final class FindPasswordViewController: BaseViewController {
         if !emailPredicate.evaluate(with: email) {
             emailErrorLabel.text = "올바른 이메일 형식이 아닙니다."
             showEmailError()
+            authCodeButton.isEnabled = true
+            isRequesting = false
             return
         }
 
-        
-        successUI()
+     
+        viewModel.setupEmail(email: email)
 
-        let authCodeVC = AuthCodeViewController(
-            viewModel: self.viewModel,
-            previousViewController: self,
-            email: email
-        )
+      
+        viewModel.sendAuthCode { [weak self] success, statusCode in
+            guard let self = self else { return }
 
-        self.navigationController?.pushViewController(authCodeVC,
-                                                     animated: true)
+            DispatchQueue.main.async {
+                self.authCodeButton.isEnabled = true
+                self.isRequesting = false
+                if success {
+                    print("인증번호 요청 성공")
+
+                    self.successUI()
+
+                    let authCodeVC = AuthCodeViewController(
+                        viewModel: self.viewModel,
+                        previousViewController: self,
+                        email: email
+                    )
+                    self.navigationController?.pushViewController(authCodeVC, animated: true)
+
+                } else {
+                    print("인증번호 요청 실패 - statusCode:", statusCode)
+                 
+                    switch statusCode {
+                    case 400:
+                        self.emailErrorLabel.text = "요청 형식이 올바르지 않습니다."
+                        self.showEmailError()
+                    case 401:
+                        self.emailErrorLabel.text = "이메일 인증이 필요합니다."
+                        self.showEmailError()
+                    case 403:
+                        self.emailErrorLabel.text = "잘못된 요청입니다."
+                        self.showEmailError()
+                    case 404:
+                        self.emailErrorLabel.text = "가입되지 않은 이메일입니다."
+                        self.showEmailError()
+                    case 500:
+                        self.emailErrorLabel.text = "서버 오류가 발생했습니다."
+                        self.showEmailError()
+                    case 429:
+                        self.emailErrorLabel.text = "잠시 후 다시 시도해주세요."
+                        self.showEmailError()
+                    default:
+                        self.emailErrorLabel.text = "인증번호 요청에 실패했습니다."
+                        self.showEmailError()
+                    }
+                }
+            }
+        }
     }
 
     private func emailBlankValue() {

--- a/Projects/Feature/Sources/Scene/Auth/NewPassword/NewPasswordViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/NewPassword/NewPasswordViewController.swift
@@ -104,9 +104,9 @@ public final class NewPasswordViewController: BaseViewController {
             return
         }
 
-        let passwordRegex = "^(?=.*[a-zA-Z])(?=.*[!@#$%^&?~])[a-zA-Z!@#$%^&?~]{6,15}$"
+        let passwordRegex = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).{6,}$"
         let passwordPredicate = NSPredicate(format: "SELF MATCHES %@", passwordRegex)
-
+        
         if !passwordPredicate.evaluate(with: password) {
             passwordFormatError.isHidden = false
             passwordFormatError.text = "잘못된 형식의 비밀번호입니다"
@@ -199,25 +199,50 @@ public final class NewPasswordViewController: BaseViewController {
             return
         }
 
-        let alert = UIAlertController(
-            title: "재설정 완료",
-            message: "비밀번호가 재설정되었습니다.",
-            preferredStyle: .alert
-        )
+        viewModel.setupEmail(email: email)
+        // ViewModel에 비밀번호 세팅
+        viewModel.setupPassword(password: password)
 
-        alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
+        // API 호출
+        viewModel.resetPassword { [weak self] success, statusCode in
+            guard let self = self else { return }
 
-            let introVC = IntroViewController()
-            let nav = UINavigationController(rootViewController: introVC)
+            DispatchQueue.main.async {
+                if success {
 
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let window = windowScene.windows.first {
-                window.rootViewController = nav
-                window.makeKeyAndVisible()
+                    let alert = UIAlertController(
+                        title: "재설정 완료",
+                        message: "비밀번호가 재설정되었습니다.",
+                        preferredStyle: .alert
+                    )
+
+                    alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
+
+                        let introVC = IntroViewController()
+                        let nav = UINavigationController(rootViewController: introVC)
+
+                        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                           let window = windowScene.windows.first {
+                            window.rootViewController = nav
+                            window.makeKeyAndVisible()
+                        }
+                    })
+
+                    self.present(alert, animated: true)
+
+                } else {
+
+                    let alert = UIAlertController(
+                        title: "오류",
+                        message: "비밀번호 재설정에 실패했습니다.",
+                        preferredStyle: .alert
+                    )
+
+                    alert.addAction(UIAlertAction(title: "확인", style: .cancel))
+                    self.present(alert, animated: true)
+                }
             }
-        })
-
-        self.present(alert, animated: true)
+        }
     }
 
     @objc private func onPasswordButtonTapped() {

--- a/Projects/Feature/Sources/Scene/Auth/NewPassword/NewPasswordViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/NewPassword/NewPasswordViewController.swift
@@ -200,10 +200,10 @@ public final class NewPasswordViewController: BaseViewController {
         }
 
         viewModel.setupEmail(email: email)
-        // ViewModel에 비밀번호 세팅
+        
         viewModel.setupPassword(password: password)
 
-        // API 호출
+    
         viewModel.resetPassword { [weak self] success, statusCode in
             guard let self = self else { return }
 

--- a/Projects/Feature/Sources/Scene/Auth/PsswordSetting/PasswordSettingViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/PsswordSetting/PasswordSettingViewController.swift
@@ -147,7 +147,7 @@ public final class PasswordSettingViewController: BaseViewController {
         let password = passwordTextField.text ?? ""
         let confirm = checkPasswordTextField.text ?? ""
 
-        // 입력 없으면 초기 상태
+     
         if confirm.isEmpty {
             passwordMatchError.isHidden = true
             checkPasswordTextField.setPlaceholderColor(.color.sub2.color)
@@ -156,7 +156,7 @@ public final class PasswordSettingViewController: BaseViewController {
             return
         }
 
-        // 비밀번호가 같으면 즉시 에러 제거
+      
         if password == confirm {
             passwordMatchError.isHidden = true
             checkPasswordTextField.layer.borderColor = UIColor.clear.cgColor
@@ -164,7 +164,7 @@ public final class PasswordSettingViewController: BaseViewController {
             return
         }
 
-        // 다르면 에러 표시
+    
         passwordMatchError.isHidden = false
         checkPasswordTextField.layer.borderColor = UIColor.systemRed.cgColor
         checkPasswordTextField.layer.borderWidth = 1

--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -261,6 +261,24 @@ public final class AuthViewModel: BaseViewModel {
             return
         }
 
+        print("=== RESET DEBUG ===")
+        print("RESET email:", email)
+        print("RESET verifiedToken:", verifiedToken)
+        print("RESET password:", password)
+
+        print("=== RESET REQUEST JSON ===")
+
+        let debugJSON: [String: Any] = [
+            "email": email,
+            "verifiedToken": verifiedToken,
+            "newPassword": password
+        ]
+
+        if let jsonData = try? JSONSerialization.data(withJSONObject: debugJSON, options: .prettyPrinted),
+           let jsonString = String(data: jsonData, encoding: .utf8) {
+            print(jsonString)
+        }
+
         let param = ResetPasswordRequest(
             email: email,
             verifiedToken: verifiedToken,

--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -261,11 +261,11 @@ public final class AuthViewModel: BaseViewModel {
             return
         }
 
-        let param: [String: Any] = [
-            "email": email,
-            "verifiedToken": verifiedToken,
-            "newPassword": password
-        ]
+        let param = ResetPasswordRequest(
+            email: email,
+            verifiedToken: verifiedToken,
+            newPassword: password
+        )
 
         authProvider.request(.resetPassword(param: param)) { response in
             switch response {

--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -153,8 +153,7 @@ public final class AuthViewModel: BaseViewModel {
             print("JSON:", jsonString)
         }
         
-        print("재요청")
-        print("URL:", "https://port-0-goms-backend-v3-mmjt7nyl6f7b9e55.sel3.cloudtype.app/api/v3/auth/email-verifications/send")
+    
         print("email:", param.email)
         print("purpose:", param.purpose)
         
@@ -261,12 +260,6 @@ public final class AuthViewModel: BaseViewModel {
             return
         }
 
-        print("=== RESET DEBUG ===")
-        print("RESET email:", email)
-        print("RESET verifiedToken:", verifiedToken)
-        print("RESET password:", password)
-
-        print("=== RESET REQUEST JSON ===")
 
         let debugJSON: [String: Any] = [
             "email": email,
@@ -340,18 +333,6 @@ public final class AuthViewModel: BaseViewModel {
             gender: gender
         )
 
-        print("SIGNUP REQUEST JSON")
-        print("""
-        {
-          "email" : "\(email)",
-          "password" : "\(password)",
-          "name" : "\(name)",
-          "grade" : \(grade),
-          "department" : "\(major.rawValue)",
-          "gender" : "\(gender.rawValue)",
-          "verifiedToken" : "\(verifiedToken)"
-        }
-        """)
 
         authProvider.request(.signUp(param: param)) { response in
             switch response {

--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -143,7 +143,7 @@ public final class AuthViewModel: BaseViewModel {
         
         let param = SendAuthCodeRequest(
             email: email,
-            purpose: AuthPurpose.signup.rawValue
+            purpose: AuthPurpose.passwordChange.rawValue
         )
         
         print("AUTH email:", param.email)
@@ -221,7 +221,7 @@ public final class AuthViewModel: BaseViewModel {
             .verifyAuthNumber(
                 email: email,
                 code: authCode,
-                purpose: AuthPurpose.signup.rawValue
+                purpose: AuthPurpose.passwordChange.rawValue
             )
         ) { response in
 
@@ -248,6 +248,49 @@ public final class AuthViewModel: BaseViewModel {
             case .failure(let error):
                 print("verifyAuthCode network error: \(error.localizedDescription)")
                 completion(false)
+            }
+        }
+    }
+
+    // MARK: - 비밀번호 재설정
+    func resetPassword(completion: @escaping (Bool, Int) -> Void) {
+
+        guard !verifiedToken.isEmpty else {
+            print("verifiedToken 없음")
+            completion(false, 0)
+            return
+        }
+
+        let param: [String: Any] = [
+            "email": email,
+            "verifiedToken": verifiedToken,
+            "newPassword": password
+        ]
+
+        authProvider.request(.resetPassword(param: param)) { response in
+            switch response {
+
+            case .success(let result):
+                print("resetPassword statusCode:", result.statusCode)
+
+                if let responseString = String(data: result.data, encoding: .utf8) {
+                    print("resetPassword response:", responseString)
+                }
+
+                completion((200..<300).contains(result.statusCode), result.statusCode)
+
+            case .failure(let error):
+                print("resetPassword error:", error.localizedDescription)
+
+                if let response = error.response {
+                    print("error statusCode:", response.statusCode)
+
+                    if let responseString = String(data: response.data, encoding: .utf8) {
+                        print("error body:", responseString)
+                    }
+                }
+
+                completion(false, 0)
             }
         }
     }

--- a/Projects/Service/Sources/Model/Auth/Common/AuthPurpose.swift
+++ b/Projects/Service/Sources/Model/Auth/Common/AuthPurpose.swift
@@ -11,4 +11,5 @@ import Foundation
 
 public enum AuthPurpose: String {
     case signup = "SIGNUP"
+    case passwordChange = "PASSWORD_CHANGE"
 }

--- a/Projects/Service/Sources/Services/Auth/AuthServices.swift
+++ b/Projects/Service/Sources/Services/Auth/AuthServices.swift
@@ -16,6 +16,7 @@ public enum AuthServices {
     case sendAuthCode(param: SendAuthCodeRequest)
     case verifyAuthNumber(email: String, code: String, purpose: String)
     case logoutToken(refreshToken: String)
+    case resetPassword(param: [String: Any])
 }
 
 extension AuthServices: TargetType {
@@ -55,6 +56,9 @@ extension AuthServices: TargetType {
 
         case .logoutToken:
             return "/api/v3/auth/signout"
+
+        case .resetPassword:
+            return "/api/v3/auth/password"
         }
     }
 
@@ -66,7 +70,8 @@ extension AuthServices: TargetType {
              .verifyAuthNumber:
             return .post
 
-        case .refreshToken:
+        case .refreshToken,
+             .resetPassword:
             return .patch
 
         case .logoutToken:
@@ -102,6 +107,9 @@ extension AuthServices: TargetType {
 
         case .logoutToken:
             return .requestPlain
+
+        case let .resetPassword(param):
+            return .requestJSONEncodable(param)
         }
     }
 

--- a/Projects/Service/Sources/Services/Auth/AuthServices.swift
+++ b/Projects/Service/Sources/Services/Auth/AuthServices.swift
@@ -9,6 +9,18 @@
 import Foundation
 import Moya
 
+public struct ResetPasswordRequest: Encodable {
+    public let email: String
+    public let verifiedToken: String
+    public let newPassword: String
+
+    public init(email: String, verifiedToken: String, newPassword: String) {
+        self.email = email
+        self.verifiedToken = verifiedToken
+        self.newPassword = newPassword
+    }
+}
+
 public enum AuthServices {
     case signUp(param: SignUpRequest)
     case signIn(param: SignInRequest)
@@ -16,7 +28,7 @@ public enum AuthServices {
     case sendAuthCode(param: SendAuthCodeRequest)
     case verifyAuthNumber(email: String, code: String, purpose: String)
     case logoutToken(refreshToken: String)
-    case resetPassword(param: [String: Any])
+    case resetPassword(param: ResetPasswordRequest)
 }
 
 extension AuthServices: TargetType {


### PR DESCRIPTION
# 🍎 개요
비밀번호 재설정 기능의 전체 흐름을 개선하고,
AuthViewModel과 ViewController 간 연결을 통해
resetPassword API를 정상적으로 연동했습니다

# 📦 작업 내용
- NewPasswordViewController ↔ AuthViewModel 데이터 연결
- resetPassword API 연동
- verifiedToken 기반 비밀번호 재설정 흐름 구현
- 요청 파라미터 디버깅 로그 추가 (email, verifiedToken, password)
- 인증번호 재요청 시 isRequesting 상태 처리 수정
