### PR TITLE
Late API 응답 구조 변경에 따른 DTO 리팩토링

### DIFF
--- a/Projects/Feature/Sources/Scene/Main/ViewModel/MainViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Main/ViewModel/MainViewModel.swift
@@ -59,8 +59,16 @@ public final class MainViewModel: BaseViewModel {
                 let responseData = result.data
                 let statusCode = result.statusCode
                 do {
-                    self.lateList = try JSONDecoder().decode([LatecomerResponse].self, from: responseData)
-                    self.lateListDatas = self.lateList.map { LatecomerData(profileImageURL: $0.profileUrl, name: $0.name, grade: $0.grade, major: $0.major) }
+                    let responseModel = try JSONDecoder().decode(LatecomerModel.self, from: responseData)
+                    self.lateList = responseModel.items
+                    self.lateListDatas = self.lateList.map {
+                        LatecomerData(
+                            profileImageURL: nil,
+                            name: $0.name,
+                            grade: $0.grade,
+                            major: $0.department.rawValue
+                        )
+                    }
                     completion()
                 } catch(let err) {
                     print(String(describing: err))

--- a/Projects/Service/Sources/Model/Late/LatecomerModel.swift
+++ b/Projects/Service/Sources/Model/Late/LatecomerModel.swift
@@ -9,14 +9,11 @@
 import Foundation
 
 public struct LatecomerModel: Codable {
-    let data: LatecomerResponse
+    public let items: [LatecomerResponse]
 }
 
 public struct LatecomerResponse: Codable {
-    public let accountIdx: UUID
     public let name: String
-    public let major: String
     public let grade: Int
-    public let gender: String
-    public let profileUrl: String?
+    public let department: Major
 }


### PR DESCRIPTION
# 🍎 개요
Late API 응답 구조 변경에 따라 Latecomer DTO를 수정했습니다

# 📦 작업 내용
- 기존 배열 응답 → items 기반 구조로 변경
- LatecomerModel 추가 (items 래핑)
- LatecomerResponse 필드 정리
  - accountIdx, gender, profileUrl 제거
  - department를 enum(Major) 기반으로 변경
