### PR TITLE
🔀 :: #111 OutingList API 변경에 따른 MainViewModel 매핑 로직 수정

### DIFF
--- a/Projects/Feature/Sources/Scene/Main/ViewModel/MainViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Main/ViewModel/MainViewModel.swift
@@ -102,8 +102,18 @@ public final class MainViewModel: BaseViewModel {
             case .success(let result):
                 let responseData = result.data
                 do {
-                    self.outingList = try JSONDecoder().decode([OutingListResponse].self, from: responseData)
-                    self.outingListDatas = self.outingList.map { OutingListData(id: $0.accountIdx, profileImageURL: $0.profileUrl, name: $0.name, grade: $0.grade, major: $0.major, outingTime: $0.createdTime) }
+                    let responseModel = try JSONDecoder().decode(OutingListModel.self, from: responseData)
+                    self.outingList = responseModel.items
+                    self.outingListDatas = self.outingList.map {
+                        OutingListData(
+                            id: UUID(),
+                            profileImageURL: nil,
+                            name: $0.name,
+                            grade: $0.grade,
+                            major: Major(rawValue: $0.department)?.rawValue ?? "",
+                            outingTime: $0.outingAt
+                        )
+                    }
                     completion()
                 } catch(let err) {
                     print(String(describing: err))

--- a/Projects/Service/Sources/Model/Outing/OutingListMoel.swift
+++ b/Projects/Service/Sources/Model/Outing/OutingListMoel.swift
@@ -9,14 +9,12 @@
 import Foundation
 
 public struct OutingListModel: Codable {
-    let data: OutingListResponse
+    public let items: [OutingListResponse]
 }
 
 public struct OutingListResponse: Codable {
-    public let accountIdx: UUID
     public let name: String
-    public let major: String
     public let grade: Int
-    public let profileUrl: String?
-    public let createdTime: String
+    public let department: String
+    public let outingAt: String
 }


### PR DESCRIPTION
# 🍎 개요
OutingList API 응답 구조 변경(items 기반)에 따라 MainViewModel의 디코딩 및 매핑 로직을 수정했습니다

# 📦 작업 내용
- OutingList 응답 구조를 배열 → items 구조로 변경 대응
- JSON 디코딩 방식 수정 ([OutingListResponse] → OutingListModel)
- 변경된 필드 반영
  - accountIdx, profileUrl 제거
  - major → department
  - createdTime → outingAt
- OutingListData 매핑 로직 수정


