### PR TITLE
🔀 :: #119 외출 현황 UI 및 시간 표시 개선

### DIFF
--- a/Projects/Feature/Sources/Scene/Main/Cell/OutingStatusCollectionViewCell.swift
+++ b/Projects/Feature/Sources/Scene/Main/Cell/OutingStatusCollectionViewCell.swift
@@ -43,7 +43,7 @@ final class OutingStatusCollectionViewCell: UICollectionViewCell {
     }
 
     // MARK: - Configure
-    func configure(with data: OutingListData) {
+    func configure(with data: OutingListData, showTime: Bool = false) {
         setupData(with: data)
     }
 
@@ -62,7 +62,7 @@ final class OutingStatusCollectionViewCell: UICollectionViewCell {
         }
         nameLabel.text = outingData.name
         if outingData.department == Major.sw.rawValue {
-            studentInfoLabel.text = "\(outingData.grade)기 | sw"
+            studentInfoLabel.text = "\(outingData.grade)기 | SW"
         } else if outingData.department == Major.iot.rawValue {
             studentInfoLabel.text = "\(outingData.grade)기 | IoT"
         } else {

--- a/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
+++ b/Projects/Feature/Sources/Scene/Main/User/View/MainViewController.swift
@@ -706,7 +706,7 @@ public final class MainViewController: BaseViewController, UICollectionViewDataS
                 cell.configureDummy()
             } else {
                 let data = mainViewModel.outingListDatas[indexPath.row]
-                cell.configure(with: data)
+                cell.configure(with: data, showTime: false)
             }
 
             return cell

--- a/Projects/Feature/Sources/Scene/Outing/User/Cell/OutingListCollectionViewCell.swift
+++ b/Projects/Feature/Sources/Scene/Outing/User/Cell/OutingListCollectionViewCell.swift
@@ -71,7 +71,7 @@ final class OutingListCollectionViewCell: UICollectionViewCell {
     }
     
     // MARK: - Configure
-    func configureData(with outingData: OutingListData) {
+    func configureData(with outingData: OutingListData, showTime: Bool = true) {
         if let imageURL = outingData.profileImageURL, let url = URL(string: imageURL) {
             profileImageView.kf.setImage(with: url, placeholder: UIImage(systemName: "person.crop.circle.fill"))
             profileImageView.layer.cornerRadius = profileImageView.frame.width / 2
@@ -86,8 +86,17 @@ final class OutingListCollectionViewCell: UICollectionViewCell {
         } else {
             studentInfoLabel.text = "\(outingData.grade)기 | AI"
         }
-        outingTime.text = "\(outingData.outingTime)에 외출"
+
+        if showTime {
+            let fullTime = outingData.outingTime
+            let timeOnly = fullTime.split(separator: "T").last?.prefix(5) ?? ""
+            outingTime.isHidden = false
+            outingTime.text = "\(timeOnly)에 외출"
+        } else {
+            outingTime.isHidden = true
+        }
     }
+    
     
     func configureUI() {
         profileImageView.layer.cornerRadius = profileImageView.frame.size.width / 2


### PR DESCRIPTION
# 🍎 개요
- 메인 화면과 외출 상세 화면의 시간 표시 방식을 분리하고, 셀 구조를 정리했습니다.

# 📦 작업 내용
- 외출 시간 표시 형식을 전체 timestamp → HH:mm 형식으로 변경
- OutingListCollectionViewCell에 시간 파싱 및 표시 로직 추가
- OutingStatusCollectionViewCell에 showTime 파라미터 추가 (메인에서는 시간 미표시)
- 메인 / 상세 화면 간 셀 역할 분리 및 configure 인터페이스 통일
- 불필요한 configureDummy() 정리
