### PR TITLE
🔀 :: #127 마이페이지 인증 및 프로필 기능 개선

### DIFF
--- a/Projects/Feature/Sources/Scene/Auth/FindPassword/FindPasswordViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/FindPassword/FindPasswordViewController.swift
@@ -96,6 +96,7 @@ public final class FindPasswordViewController: BaseViewController {
 
      
         viewModel.setupEmail(email: email)
+        viewModel.setupEmailStatus(status: "PASSWORD_CHANGE")
 
       
         viewModel.sendAuthCode { [weak self] success, statusCode in

--- a/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
+++ b/Projects/Feature/Sources/Scene/Auth/SignUp/SignUpViewController.swift
@@ -259,6 +259,7 @@ public final class SignUpViewController: BaseViewController {
         let name = nameTextField.text ?? ""
         let email = emailTextField.text ?? ""
         viewModel.setupEmail(email: email)
+        viewModel.setupEmailStatus(status: "SIGNUP")
 
         nameErrorLabel.isHidden = true
         emailErrorLabel.isHidden = true

--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -145,10 +145,10 @@ public final class AuthViewModel: BaseViewModel {
 
     func sendAuthCode(completion: @escaping (Bool, Int) -> Void) {
         
-        // 민선: Swagger에 맞춰 purpose를 "SIGNUP"으로 수정함
+        // 비밀번호 찾기랑 이넘 분기했습니다
         let param = SendAuthCodeRequest(
             email: email,
-            purpose: emailStatus
+            purpose: emailStatus.isEmpty ? "SIGNUP" : emailStatus
         )
         
         print("AUTH email:", param.email)

--- a/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Auth/ViewModel/AuthViewModel.swift
@@ -64,6 +64,10 @@ public final class AuthViewModel: BaseViewModel {
         self.grade = grade
     }
 
+    func setupEmailStatus(status: String) {
+        self.emailStatus = status
+    }
+
     func signIn(completion: @escaping (Int, String?) -> Void) {
 
         let param = SignInRequest(email: email, password: password)
@@ -144,7 +148,7 @@ public final class AuthViewModel: BaseViewModel {
         // 민선: Swagger에 맞춰 purpose를 "SIGNUP"으로 수정함
         let param = SendAuthCodeRequest(
             email: email,
-            purpose: "SIGNUP"
+            purpose: emailStatus
         )
         
         print("AUTH email:", param.email)
@@ -221,7 +225,7 @@ public final class AuthViewModel: BaseViewModel {
             .verifyAuthNumber(
                 email: email,
                 code: authCode,
-                purpose: "SIGNUP" // 민선: 여기도 똑같이 "SIGNUP"으로 수정
+                purpose: emailStatus // 민선: 여기도 똑같이 "SIGNUP"으로 수정
             )
         ) { response in
 

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
@@ -421,16 +421,18 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
         }))
         actionSheet.addAction(UIAlertAction(title: "기본 프로필 사용", style: .default, handler: { [weak self] (ACTION:UIAlertAction) in
             self?.userProfile.image = .image.gomsBasicProfile.image
-            self?.profileViewModel.deleteProfileImage()
-                .sink { completion in
-                    switch completion {
-                    case .finished:
-                        print("기본 프로필 삭제 완료")
-                    case .failure(let error):
-                        print("삭제 실패: \(error)")
-                    }
-                } receiveValue: { _ in }
-                .store(in: &self!.cancellables)
+            if let self = self {
+                self.profileViewModel.deleteProfileImage()
+                    .sink { completion in
+                        switch completion {
+                        case .finished:
+                            print("기본 프로필 삭제 완료")
+                        case .failure(let error):
+                            print("삭제 실패: \(error)")
+                        }
+                    } receiveValue: { _ in }
+                    .store(in: &self.cancellables)
+            }
         }))
         actionSheet.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { [weak self] _ in
             self?.updateImage(isActionSheetShowing: false)

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Admin/AdminProfileViewController.swift
@@ -289,14 +289,23 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
         alertController.addAction(cancelAction)
 
         let confirmAction = UIAlertAction(title: "로그아웃", style: .destructive) { [weak self] _ in
-            
-            let introVC = IntroViewController()
-            let nav = UINavigationController(rootViewController: introVC)
+            guard let self = self else { return }
 
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let window = windowScene.windows.first {
-                window.rootViewController = nav
-                window.makeKeyAndVisible()
+            self.profileViewModel.profileLogout { success in
+                DispatchQueue.main.async {
+                    if success {
+                        let introVC = IntroViewController()
+                        let nav = UINavigationController(rootViewController: introVC)
+
+                        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                           let window = windowScene.windows.first {
+                            window.rootViewController = nav
+                            window.makeKeyAndVisible()
+                        }
+                    } else {
+                        print("로그아웃 실패")
+                    }
+                }
             }
         }
 
@@ -412,14 +421,21 @@ public class AdminProfileViewController: BaseViewController,UIImagePickerControl
         }))
         actionSheet.addAction(UIAlertAction(title: "기본 프로필 사용", style: .default, handler: { [weak self] (ACTION:UIAlertAction) in
             self?.userProfile.image = .image.gomsBasicProfile.image
-            let viewModel = ProfileViewModel()
-            viewModel.deleteProfileImage()
+            self?.profileViewModel.deleteProfileImage()
+                .sink { completion in
+                    switch completion {
+                    case .finished:
+                        print("기본 프로필 삭제 완료")
+                    case .failure(let error):
+                        print("삭제 실패: \(error)")
+                    }
+                } receiveValue: { _ in }
+                .store(in: &self!.cancellables)
         }))
         actionSheet.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { [weak self] _ in
             self?.updateImage(isActionSheetShowing: false)
         }))
 
-        
         if let popover = actionSheet.popoverPresentationController {
             popover.sourceView = sender
             popover.sourceRect = sender.bounds

--- a/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
@@ -198,9 +198,9 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
         let alert = UIAlertController(title: "회원 탈퇴", message: "정말로 회원을 탈퇴하시겠습니까?", preferredStyle: .alert)
         
         let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
-        let withdrawal = UIAlertAction(title: "회원 탈퇴", style: .destructive) { action in
+        let withdrawal = UIAlertAction(title: "회원 탈퇴", style: .destructive) { [weak self] _ in
             let withdrawalVC = WithdrawalViewController()
-            self.navigationController?.pushViewController(withdrawalVC , animated: true)
+            self?.navigationController?.pushViewController(withdrawalVC, animated: true)
         }
         
         alert.addAction(cancel)
@@ -307,16 +307,23 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
         alertController.addAction(cancelAction)
         
         let confirmAction = UIAlertAction(title: "로그아웃", style: .destructive) { [weak self] _ in
-            
-            let introVC = IntroViewController()
-            let nav = UINavigationController(rootViewController: introVC)
+            self?.profileViewModel.profileLogout { success in
+                DispatchQueue.main.async {
+                    if success {
+                        let introVC = IntroViewController()
+                        let nav = UINavigationController(rootViewController: introVC)
 
-            if let window = UIApplication.shared.connectedScenes
-                .compactMap({ $0 as? UIWindowScene })
-                .first?.windows.first {
+                        if let window = UIApplication.shared.connectedScenes
+                            .compactMap({ $0 as? UIWindowScene })
+                            .first?.windows.first {
 
-                window.rootViewController = nav
-                window.makeKeyAndVisible()
+                            window.rootViewController = nav
+                            window.makeKeyAndVisible()
+                        }
+                    } else {
+                        print("로그아웃 실패")
+                    }
+                }
             }
         }
         

--- a/Projects/Feature/Sources/Scene/Profile/Controller/Withdrawal/WithdrawalViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/Withdrawal/WithdrawalViewController.swift
@@ -56,28 +56,47 @@ public class WithdrawalViewController: BaseViewController {
     @objc func withdrawalButtonTapped() {
         let inputPassword = passwordTextField.text ?? ""
 
-        if inputPassword == "1234" {
-            passwordErrorLabel.isHidden = true
-            passwordTextField.layer.borderWidth = 0
-            passwordTextField.setPlaceholderColor(.color.sub2.color)
+        guard !inputPassword.isEmpty else {
+            passwordErrorUI()
+            return
+        }
 
-            let alert = UIAlertController(title: "회원 탈퇴 완료", message: "그동안 GOMS를 이용해주셔서 감사합니다.\n안녕히 가세요!", preferredStyle: .alert)
+        viewModel.setupPassword(password: inputPassword)
 
-            let ok = UIAlertAction(title: "완료", style: .default) { _ in
-                let introVC = IntroViewController()
-                let nav = UINavigationController(rootViewController: introVC)
+        viewModel.withdraw { [weak self] success in
+            guard let self = self else { return }
 
-                if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                   let window = scene.windows.first {
-                    window.rootViewController = nav
-                    window.makeKeyAndVisible()
+            DispatchQueue.main.async {
+                if success {
+                    self.passwordErrorLabel.isHidden = true
+                    self.passwordTextField.layer.borderWidth = 0
+                    self.passwordTextField.setPlaceholderColor(.color.sub2.color)
+
+                    let alert = UIAlertController(
+                        title: "회원 탈퇴 완료",
+                        message: "그동안 GOMS를 이용해주셔서 감사합니다.\n안녕히 가세요!",
+                        preferredStyle: .alert
+                    )
+
+                    let ok = UIAlertAction(title: "완료", style: .default) { _ in
+                        let introVC = IntroViewController()
+                        let nav = UINavigationController(rootViewController: introVC)
+
+                        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                           let window = scene.windows.first {
+                            window.rootViewController = nav
+                            window.makeKeyAndVisible()
+                        }
+                    }
+
+                    alert.addAction(ok)
+                    self.present(alert, animated: true)
+
+                } else {
+                    self.passwordErrorLabel.text = self.viewModel.errorMessage
+                    self.passwordErrorUI()
                 }
             }
-            alert.addAction(ok)
-            self.present(alert, animated: true)
-        } else {
-            print("탈퇴하기 실패")
-            self.passwordErrorUI()
         }
     }
     

--- a/Projects/Feature/Sources/Scene/Profile/ViewModel/ProfileViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Profile/ViewModel/ProfileViewModel.swift
@@ -28,7 +28,7 @@ public final class ProfileViewModel: BaseViewModel, ObservableObject {
         super.init()
     }
 
-    let providerAuccount = MoyaProvider<AccountServices>(plugins: [NetworkLoggerPlugin()])
+
     let providerMember = MoyaProvider<MemberServices>(plugins: [NetworkLoggerPlugin()])
     let providerAuth = MoyaProvider<AuthServices>(plugins: [NetworkLoggerPlugin()])
     let providerOuting = MoyaProvider<OutingServices>(plugins: [NetworkLoggerPlugin()])
@@ -170,7 +170,7 @@ public final class ProfileViewModel: BaseViewModel, ObservableObject {
     }
 
     public func withdraw(completion: @escaping (Bool) -> Void) {
-        providerAuccount.request(.withdraw(password: self.password, authorization: accessToken)) { [weak self] response in
+        providerMember.request(.withdraw(password: self.password, authorization: accessToken)) { [weak self] response in
             guard let self = self else { return }
             
             switch response {

--- a/Projects/Feature/Sources/Scene/Profile/ViewModel/ProfileViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Profile/ViewModel/ProfileViewModel.swift
@@ -170,27 +170,46 @@ public final class ProfileViewModel: BaseViewModel, ObservableObject {
     }
 
     public func withdraw(completion: @escaping (Bool) -> Void) {
-        providerAuccount.request(.withdraw(password: self.password, authorization: accessToken)) { response in
+        providerAuccount.request(.withdraw(password: self.password, authorization: accessToken)) { [weak self] response in
+            guard let self = self else { return }
+            
             switch response {
             case .success(let result):
                 let statusCode = result.statusCode
+                
                 switch statusCode {
-                case 205:
-                    print(result.data)
+                case 200:
+                   
+                    self.keyChain.delete(key: Const.KeyChainKey.accessToken)
+                    self.keyChain.delete(key: Const.KeyChainKey.refreshToken)
+                    
+                    print("회원탈퇴 성공")
                     completion(true)
-                case 404:
-                    print(result.data)
-                    completion(false)
+                    
                 case 400:
-                    print("현재 비밀번호 입력 String: \(self.password)")
-                    print(result.data)
+                    self.errorMessage = "요청 형식이 잘못되었습니다."
                     completion(false)
+                    
+                case 401:
+                    self.errorMessage = "인증이 만료되었습니다. 다시 로그인해주세요."
+                    completion(false)
+                    
+                case 403:
+                    self.errorMessage = "비밀번호가 올바르지 않습니다."
+                    completion(false)
+                    
+                case 500:
+                    self.errorMessage = "서버 오류가 발생했습니다."
+                    completion(false)
+                    
                 default:
-                    print(result)
+                    self.errorMessage = "알 수 없는 오류"
                     completion(false)
                 }
+                
             case .failure(let err):
-                print(err.localizedDescription)
+                self.errorMessage = err.localizedDescription
+                print("withdraw error: \(err.localizedDescription)")
                 completion(false)
             }
         }

--- a/Projects/Service/Sources/Services/Account/AccountServices.swift
+++ b/Projects/Service/Sources/Services/Account/AccountServices.swift
@@ -12,7 +12,6 @@ import Moya
 public enum AccountServices {
     case newPassword(param: NewPasswordRequest)
     case changPassword(param: ChangPasswordRequest, authorization: String)
-    case withdraw(password: String, authorization: String)
 }
 
 extension AccountServices: TargetType {
@@ -30,8 +29,6 @@ extension AccountServices: TargetType {
             return "/account/new-password"
         case .changPassword:
             return "/account/change-password"
-        case .withdraw(let password, _):
-            return "/account/withdraw/\(password)"
         }
     }
     
@@ -39,8 +36,6 @@ extension AccountServices: TargetType {
         switch self {
         case .newPassword, .changPassword:
             return .patch
-        case .withdraw:
-            return .delete
         }
     }
     
@@ -54,8 +49,6 @@ extension AccountServices: TargetType {
             return .requestJSONEncodable(param)
         case .changPassword(let param, _):
             return .requestJSONEncodable(param)
-        case .withdraw:
-            return .requestPlain
         }
     }
     
@@ -63,8 +56,7 @@ extension AccountServices: TargetType {
         switch self {
         case .newPassword:
             return ["Content-Type": "application/json"]
-        case .changPassword(_, let authorization),
-             .withdraw(_, let authorization):
+        case .changPassword(_, let authorization):
             return ["Content-Type": "application/json", "Authorization": authorization]
         default:
             return ["Content-Type": "application/json"]


### PR DESCRIPTION
# 🍎 개요
마이페이지 인증 및 프로필 기능을 개선하고,  
로그아웃과 이미지 처리 로직을 정상화했습니다

# 📦 작업 내용
- 로그아웃 시 서버 API 호출 후 토큰 삭제하도록 수정
- 기본 프로필 선택 시 이미지 삭제 API 정상 동작하도록 수정
- 잘못된 ViewModel 인스턴스 생성 제거
- 이메일 인증 purpose 값 수정
- 비밀번호 찾기 인증 로직 추가
- 마이페이지 및 인증 흐름 안정화