### PR TITLE
🔀 :: #133 UserProfileView UI 개선 및 Admin 레이아웃 기준 통일

### DIFF
--- a/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
@@ -676,19 +676,19 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
         }
 
         passwordResetButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(48)
             $0.top.equalTo(themeBottomLine.snp.bottom).offset(24)
         }
 
         logoutButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(48)
             $0.top.equalTo(passwordResetButton.snp.bottom).offset(0)
         }
 
         withdrawalButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(48)
             $0.top.equalTo(logoutButton.snp.bottom)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)

--- a/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
+++ b/Projects/Feature/Sources/Scene/Profile/Controller/User/UserProfileViewController.swift
@@ -36,7 +36,7 @@ public class UserProfileViewController: BaseViewController, UIImagePickerControl
     }
     
     let userProfilePencil = UIButton().then {
-        $0.setImage(.image.adminpencil.image, for: .normal)
+        $0.setImage(.image.gomsProfilePencil.image, for: .normal)
         $0.addTarget(self, action: #selector(ShowActionSheetProfilImageChange), for: .touchUpInside)
 
         $0.layer.shadowColor = UIColor.black.cgColor


### PR DESCRIPTION
# 🍎 개요
UserProfileView와 AdminProfileView 간 UI 불일치를 해소하고, 동일한 레이아웃 기준으로 통일합니다.

# 📦 작업 내용
- UserProfileView 버튼 레이아웃을 AdminProfileView 기준으로 통일
  - 좌우 inset 제거 → full width 적용
- 프로필 수정 버튼(admin pencil) UI 위치 및 스타일 수정

