### PR TITLE
🔀 :: #135 MapViewController 지도 렌더링 이슈 수정 (push-pop 대응)

### DIFF
--- a/Projects/Feature/Sources/Scene/Map/View/MapViewControlle.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapViewControlle.swift
@@ -272,8 +272,10 @@ public final class MapViewController: UIViewController {
         controller.prepareEngine()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            guard let self = self else { return }
-            self.mapController?.activateEngine()
+            guard let self = self,
+                  let controller = self.mapController else { return }
+
+            controller.activateEngine()
 
             let defaultPosition = MapPoint(longitude: 127.0326, latitude: 37.4980)
             let mapviewInfo = MapviewInfo(
@@ -283,7 +285,7 @@ public final class MapViewController: UIViewController {
                 defaultLevel: 15
             )
 
-            self.mapController?.addView(mapviewInfo)
+            controller.addView(mapviewInfo)
         }
     }
     deinit {

--- a/Projects/Feature/Sources/Scene/Map/View/MapViewControlle.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapViewControlle.swift
@@ -64,6 +64,8 @@ public final class MapViewController: UIViewController {
 
         if mapController == nil {
             setupMap()
+        } else {
+            mapController?.activateEngine()
         }
     }
 
@@ -269,8 +271,9 @@ public final class MapViewController: UIViewController {
 
         controller.prepareEngine()
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            controller.activateEngine()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            guard let self = self else { return }
+            self.mapController?.activateEngine()
 
             let defaultPosition = MapPoint(longitude: 127.0326, latitude: 37.4980)
             let mapviewInfo = MapviewInfo(
@@ -280,7 +283,7 @@ public final class MapViewController: UIViewController {
                 defaultLevel: 15
             )
 
-            controller.addView(mapviewInfo)
+            self.mapController?.addView(mapviewInfo)
         }
     }
     deinit {

--- a/Projects/Feature/Sources/Scene/Map/View/MapViewControlle.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapViewControlle.swift
@@ -15,7 +15,6 @@ public final class MapViewController: UIViewController {
     
     private var mapContainer: KMViewContainer?
     private var mapController: KMController?
-    private var isMapInitialized = false
     private let mapWrapperView = UIView()
     
     private var dummyRecentSearches = MapMockData.recentSearches
@@ -63,34 +62,8 @@ public final class MapViewController: UIViewController {
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        guard !isMapInitialized else { return }
-        isMapInitialized = true
-
-        mapWrapperView.layoutIfNeeded()
-
-        let container = KMViewContainer(frame: mapWrapperView.bounds)
-        container.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        mapWrapperView.addSubview(container)
-        self.mapContainer = container
-
-        let controller = KMController(viewContainer: container)
-        self.mapController = controller
-
-        controller.prepareEngine()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            controller.activateEngine()
-
-    
-            let defaultPosition = MapPoint(longitude: 127.0326, latitude: 37.4980)
-            let mapviewInfo = MapviewInfo(
-                viewName: "mapview",
-                viewInfoName: "map",
-                defaultPosition: defaultPosition,
-                defaultLevel: 15
-            )
-
-            controller.addView(mapviewInfo)
+        if mapController == nil {
+            setupMap()
         }
     }
 
@@ -284,7 +257,31 @@ public final class MapViewController: UIViewController {
     }
     
     private func setupMap() {
-   
+        mapWrapperView.layoutIfNeeded()
+
+        let container = KMViewContainer(frame: mapWrapperView.bounds)
+        container.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapWrapperView.addSubview(container)
+        self.mapContainer = container
+
+        let controller = KMController(viewContainer: container)
+        self.mapController = controller
+
+        controller.prepareEngine()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            controller.activateEngine()
+
+            let defaultPosition = MapPoint(longitude: 127.0326, latitude: 37.4980)
+            let mapviewInfo = MapviewInfo(
+                viewName: "mapview",
+                viewInfoName: "map",
+                defaultPosition: defaultPosition,
+                defaultLevel: 15
+            )
+
+            controller.addView(mapviewInfo)
+        }
     }
     deinit {
         mapController?.pauseEngine()
@@ -296,11 +293,6 @@ public final class MapViewController: UIViewController {
         super.viewDidDisappear(animated)
 
         mapController?.pauseEngine()
-        mapController?.resetEngine()
-        mapController = nil
-
-        mapContainer?.removeFromSuperview()
-        mapContainer = nil
     }
 }
 


### PR DESCRIPTION
# 🍎 개요
push/pop 이후 Map 화면에서 지도가 렌더링되지 않는 문제를 해결했습니다

# 📦 작업 내용
- 지도 초기화 플래그(isMapInitialized) 제거
- mapController 상태 기반으로 지도 생성 조건 수정
- viewDidAppear에서 map 재생성 로직 추가
- viewDidDisappear에서 map 완전 제거 대신 pause 처리
