### PR TITLE
 🔀 :: #139 QR 코드 생성 및 외출 API 연동 (exp 기반 처리)

### DIFF
--- a/Projects/Feature/Sources/QR/View/AdminQRViewController.swift
+++ b/Projects/Feature/Sources/QR/View/AdminQRViewController.swift
@@ -87,7 +87,8 @@ public class AdminQRViewController: BaseViewController {
     }
     
     private func startTimer() {
-        Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { (t) in
+        Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] (t) in
+            guard let self = self else { return }
             self.timer -= 1
             let minutes = self.timer / 60
             let seconds = self.timer % 60
@@ -103,9 +104,19 @@ public class AdminQRViewController: BaseViewController {
     }
     
     private func createQRCode() {
-        viewModel.makeQR { success in
+        viewModel.makeQR { [weak self] success in
+            guard let self = self else { return }
+            
             if success {
                 let outingUUIDString = self.viewModel.outingUUID.uuidString
+                
+             
+                if self.viewModel.exp > 0 {
+                    let currentTime = Int(Date().timeIntervalSince1970 * 1000)
+                    let remaining = (self.viewModel.exp - currentTime) / 1000
+                    self.timer = max(remaining, 0)
+                }
+                
                 if let qrCodeImage = self.generateQRCode(from: outingUUIDString) {
                     DispatchQueue.main.async {
                         self.qrCodeImage.image = qrCodeImage

--- a/Projects/Feature/Sources/QR/ViewModel/QRCodeViewModel.swift
+++ b/Projects/Feature/Sources/QR/ViewModel/QRCodeViewModel.swift
@@ -17,8 +17,9 @@ public final class QRCodeViewModel: BaseViewModel {
     private let outingProvider = MoyaProvider<OutingServices>()
     private let profileViewModel = ProfileViewModel()
     
-    public var outingUUID: UUID = UUID()
-    private var isRequesting: Bool = false
+public var outingUUID: UUID = UUID()
+public var exp: Int = 0
+private var isRequesting: Bool = false
 
     func outing(completion: @escaping (String) -> Void) {
         guard !isRequesting else {
@@ -27,7 +28,8 @@ public final class QRCodeViewModel: BaseViewModel {
         }
         
         isRequesting = true
-        outingProvider.request(.outingOut(uuid: outingUUID.uuidString, exp: 0, authorization: accessToken)) { response in
+        outingProvider.request(.outingOut(uuid: outingUUID.uuidString, exp: self.exp, authorization: accessToken)) { response in
+            defer { self.isRequesting = false }
             switch response {
             case .success(let result):
                 let statusCode = result.statusCode
@@ -61,7 +63,9 @@ public final class QRCodeViewModel: BaseViewModel {
                         }
                     }
                 case 401:
-                    self.gomsRefreshToken.tokenReissuance(){ success in}
+                    self.gomsRefreshToken.tokenReissuance() { _ in
+                        completion("fail")
+                    }
                 case 500:
                     print("SERVER ERROR")
                 default:
@@ -82,18 +86,26 @@ public final class QRCodeViewModel: BaseViewModel {
                 case 200:
                     do {
                         let responseJSON = try result.mapJSON() as? [String: Any]
-                        if let outingUUIDString = responseJSON?["outingUUID"] as? String,
-                           let outingUUID = UUID(uuidString: outingUUIDString) {
+                        if let uuidString = responseJSON?["uuid"] as? String,
+                           let exp = responseJSON?["exp"] as? Int,
+                           let outingUUID = UUID(uuidString: uuidString) {
+                            
                             self.outingUUID = outingUUID
+                            self.exp = exp
                             completion(true)
+                            
                         } else {
-                            print("outingUUID를 가져올 수 없습니다.")
+                            print("uuid 또는 exp를 가져올 수 없습니다.")
+                            completion(false)
                         }
                     } catch {
                         print(error.localizedDescription)
+                        completion(false)
                     }
                 case 401:
-                    self.gomsRefreshToken.tokenReissuance(){ success in}
+                    self.gomsRefreshToken.tokenReissuance() { _ in
+                        completion(false)
+                    }
                 case 403:
                     print("학생회 계정이 아닌데 요청할 경우")
                     completion(false)

--- a/Projects/Feature/Sources/Scene/Outing/ViewModel/OutingViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Outing/ViewModel/OutingViewModel.swift
@@ -29,7 +29,7 @@ public final class OutingViewModel: BaseViewModel {
     var outingSearchList: [OutingSearchResponse] = []
     var outingSearchListDatas: [OutingListData] = []
     
-    func getOutingList(completion: @escaping () -> Void) {
+    func getOutingList(isRetry: Bool = false, completion: @escaping () -> Void) {
         outingProvider.request(.outingList(authorization: accessToken)) { response in
             switch response {
             case .success(let result):
@@ -55,7 +55,15 @@ public final class OutingViewModel: BaseViewModel {
                         print(String(describing: err))
                     }
                 case 401:
-                    self.gomsRefreshToken.tokenReissuance(){ success in}
+                    if isRetry {
+                        print("재시도 실패 (getOutingList)")
+                        return
+                    }
+                    self.gomsRefreshToken.tokenReissuance() { success in
+                        if success {
+                            self.getOutingList(isRetry: true, completion: completion)
+                        }
+                    }
                 case 404:
                     print("외출한 사람이 없을 경우")
                 default:
@@ -67,7 +75,7 @@ public final class OutingViewModel: BaseViewModel {
         }
     }
     
-    func searchStudent(searchString: String, completion: @escaping () -> Void) {
+    func searchStudent(searchString: String, isRetry: Bool = false, completion: @escaping () -> Void) {
         outingProvider.request(.outingSearch(name: searchString, authorization: accessToken)) { response in
             switch response {
             case .success(let result):
@@ -94,7 +102,15 @@ public final class OutingViewModel: BaseViewModel {
                 case 200:
                     print("success")
                 case 401:
-                    self.gomsRefreshToken.tokenReissuance(){ success in}
+                    if isRetry {
+                        print("재시도 실패 (searchStudent)")
+                        return
+                    }
+                    self.gomsRefreshToken.tokenReissuance() { success in
+                        if success {
+                            self.searchStudent(searchString: searchString, isRetry: true, completion: completion)
+                        }
+                    }
                 default:
                     print(result)
                 }
@@ -104,7 +120,7 @@ public final class OutingViewModel: BaseViewModel {
         }
     }
     
-    func deleteOutingStudent(user: OutingListData, completion: @escaping () -> Void) {
+    func deleteOutingStudent(user: OutingListData, isRetry: Bool = false, completion: @escaping () -> Void) {
         let deleteStudent = user.id
 
         studentCouncilProvider.request(
@@ -121,7 +137,15 @@ public final class OutingViewModel: BaseViewModel {
                     print("잘못된 요청")
 
                 case 401:
-                    self.gomsRefreshToken.tokenReissuance(){ _ in }
+                    if isRetry {
+                        print("재시도 실패 (deleteOutingStudent)")
+                        return
+                    }
+                    self.gomsRefreshToken.tokenReissuance() { success in
+                        if success {
+                            self.deleteOutingStudent(user: user, isRetry: true, completion: completion)
+                        }
+                    }
 
                 case 403:
                     print("권한 없음 / 외출 불가 상태")
@@ -141,7 +165,7 @@ public final class OutingViewModel: BaseViewModel {
         }
     }
 
-    func forceOutingStudent(user: OutingListData, completion: @escaping () -> Void) {
+    func forceOutingStudent(user: OutingListData, isRetry: Bool = false, completion: @escaping () -> Void) {
         let forceOutingStudent = user.id
 
         studentCouncilProvider.request(
@@ -158,7 +182,15 @@ public final class OutingViewModel: BaseViewModel {
                     print("QR 만료 또는 요청 값 오류")
 
                 case 401:
-                    self.gomsRefreshToken.tokenReissuance(){ _ in }
+                    if isRetry {
+                        print("재시도 실패 (forceOutingStudent)")
+                        return
+                    }
+                    self.gomsRefreshToken.tokenReissuance() { success in
+                        if success {
+                            self.forceOutingStudent(user: user, isRetry: true, completion: completion)
+                        }
+                    }
 
                 case 403:
                     print("외출 불가 상태 (CANNOT_OUTING)")

--- a/Projects/Service/Sources/Model/StudentCouncil/MakeQRModel.swift
+++ b/Projects/Service/Sources/Model/StudentCouncil/MakeQRModel.swift
@@ -9,5 +9,6 @@
 import Foundation
 
 public struct MakeQRCodeResponse: Codable {
-    let outingUUID: UUID
+    let uuid: String
+    let exp: Int
 }


### PR DESCRIPTION
# 🍎 개요
QR 코드 생성 및 외출 처리 기능을 서버 API와 연동하고,  
exp(만료 시간) 기반으로 유효시간 로직을 적용했습니다

# 📦 작업 내용
- QR 코드 생성 API 연동
  - uuid, exp 값 파싱 및 상태 저장
- exp 기반 QR 만료 시간 처리 로직 추가
- 외출 요청 시 exp 값 포함하도록 수정
- QR 코드 생성 → 외출 흐름 전체 연결
- 중복 요청 방지 로직 추가 (isRequesting)
- 비동기 처리 안정성 개선
  - completion 누락 케이스 보완
