### PR TITLE
🔀 :: #182 바텀시트 후기 삭제 흐름 및 핸들 터치 영역 개선

### DIFF
--- a/Projects/Feature/Sources/Scene/Map/View/MapBottomSheetView.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapBottomSheetView.swift
@@ -220,7 +220,7 @@ public final class MapBottomSheetView: UIView {
         guard index < reviewPlaces.count else { return }
         let placeId = reviewPlaces[index].id
         onDeleteTapped?(placeId)
-        // 삭제는 ViewController에서 API 성공 후 데이터 갱신으로 처리
+       
     }
 
     @objc private func didTapCard(_ sender: UITapGestureRecognizer) {

--- a/Projects/Feature/Sources/Scene/Map/View/MapBottomSheetView.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapBottomSheetView.swift
@@ -212,8 +212,7 @@ public final class MapBottomSheetView: UIView {
         guard index < reviewPlaces.count else { return }
         let placeId = reviewPlaces[index].id
         onDeleteTapped?(placeId)
-        reviewPlaces.remove(at: index)
-        renderUI()
+        // 삭제는 ViewController에서 API 성공 후 데이터 갱신으로 처리
     }
 
     @objc private func didTapCard(_ sender: UITapGestureRecognizer) {

--- a/Projects/Feature/Sources/Scene/Map/View/MapBottomSheetView.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapBottomSheetView.swift
@@ -52,6 +52,7 @@ public final class MapBottomSheetView: UIView {
         $0.backgroundColor = UIColor.color.gomsDivider.color
         $0.layer.cornerRadius = 2.5
     }
+    private let handleTouchArea = UIView()
     private let scrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
         $0.alwaysBounceVertical = true
@@ -93,19 +94,26 @@ public final class MapBottomSheetView: UIView {
     }
 
     private func addView() {
-        addSubview(handleView)
+        addSubview(handleTouchArea)
+        handleTouchArea.addSubview(handleView)
         addSubview(scrollView)
         scrollView.addSubview(contentStackView)
     }
     
     private func setLayout() {
+        handleTouchArea.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(40)
+        }
+
         handleView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(8)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(40); $0.height.equalTo(5)
+            $0.center.equalToSuperview()
+            $0.width.equalTo(40)
+            $0.height.equalTo(5)
         }
         scrollView.snp.makeConstraints {
-            $0.top.equalTo(handleView.snp.bottom).offset(8)
+            $0.top.equalTo(handleTouchArea.snp.bottom).offset(8)
             $0.leading.trailing.bottom.equalToSuperview()
         }
         contentStackView.snp.makeConstraints {

--- a/Projects/Feature/Sources/Scene/Map/View/MapViewController.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapViewController.swift
@@ -72,6 +72,9 @@ private let recentSearchView = MapRecentSearchView().then {
     $0.tableView.backgroundColor = .color.background.color
 }
 private let bottomSheetView = MapBottomSheetView()
+private let bottomSheetHandleTouchArea = UIView().then {
+    $0.backgroundColor = .clear
+}
 private let placeDetailView = MapPlaceDetailView().then {
     $0.isHidden = true
     $0.clipsToBounds = true
@@ -80,7 +83,7 @@ private let placeDetailView = MapPlaceDetailView().then {
 private var bottomSheetHeight: Constraint?
 private var detailSheetHeight: Constraint?
 private let defaultHeight: CGFloat = 240
-private let firstHeight: CGFloat = 20
+private let firstHeight: CGFloat = 30
 private let detailMinHeight: CGFloat = 225
 private var selectedPlaceId: Int = -1
 private var currentPlaceDetail: MapPlaceDetailModel?
@@ -204,7 +207,7 @@ private func setupView() {
     self.view.backgroundColor = .black
     view.backgroundColor = .color.background.color
     view.addSubview(mapWrapperView)
-    [bottomSheetView, recentSearchView, routeSelectionView, placeDetailView, searchBar].forEach { view.addSubview($0) }
+    [bottomSheetView, bottomSheetHandleTouchArea, recentSearchView, routeSelectionView, placeDetailView, searchBar].forEach { view.addSubview($0) }
 }
 
 private func setupLayout() {
@@ -218,6 +221,11 @@ private func setupLayout() {
     bottomSheetView.snp.makeConstraints {
         $0.leading.trailing.bottom.equalToSuperview()
         self.bottomSheetHeight = $0.height.equalTo(defaultHeight).constraint
+    }
+    bottomSheetHandleTouchArea.snp.makeConstraints {
+        $0.leading.trailing.equalToSuperview()
+        $0.bottom.equalTo(bottomSheetView.snp.top)
+        $0.height.equalTo(30)
     }
     placeDetailView.snp.makeConstraints {
         $0.leading.trailing.bottom.equalToSuperview()
@@ -733,6 +741,7 @@ private func styleIDForCategory(_ category: String) -> String {
 }
 
 private func setupGesture() {
+    bottomSheetHandleTouchArea.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(handlePan)))
     bottomSheetView.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(handlePan)))
     placeDetailView.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(handlePan)))
 }


### PR DESCRIPTION
# 🍎 개요
바텀시트 후기 삭제 시 UI가 알럿 이전에 먼저 반영되던 문제를 수정하고,  
핸들 터치 영역을 확장하여 드래그 UX를 개선했습니다.

# 📦 작업 내용
### 1. 바텀시트 후기 삭제 로직 수정
- 삭제 버튼 클릭 시 UI가 먼저 반영되던 문제 수정
- BottomSheet에서 직접 데이터 제거하던 로직 제거
- 삭제는 ViewController → API 성공 이후 → UI 갱신 흐름으로 변경

### 2. 바텀시트 핸들 터치 영역 개선
- 핸들 영역이 작아 드래그가 어려운 문제 수정
- handleTouchArea를 추가하여 터치 영역 확장
- 드래그 제스처 인식 개선
