### PR TITLE
 🔀 :: 학생관리 데이터 qa 반영

### DIFF
--- a/Projects/Feature/Sources/StudentManagement/BottomSheet/AuthorityBottomSheetVC.swift
+++ b/Projects/Feature/Sources/StudentManagement/BottomSheet/AuthorityBottomSheetVC.swift
@@ -141,19 +141,23 @@ public final class AuthorityBottomSheetVC: BaseViewController {
             action: { [weak self] in
                 if isOn {
                     self?.viewModel.forceOutingStudent(user: data) { [weak self] in
-                        guard let self = self else { return }
-                        if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
-                            self.userData = updated
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self else { return }
+                            if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
+                                self.userData = updated
+                            }
+                            self.studentManagementVC.userList = self.viewModel.userListDatas
                         }
-                        self.studentManagementVC.userList = self.viewModel.userListDatas
                     }
                 } else {
                     self?.viewModel.deleteOutingStudent(user: data) { [weak self] in
-                        guard let self = self else { return }
-                        if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
-                            self.userData = updated
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self else { return }
+                            if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
+                                self.userData = updated
+                            }
+                            self.studentManagementVC.userList = self.viewModel.userListDatas
                         }
-                        self.studentManagementVC.userList = self.viewModel.userListDatas
                     }
                 }
             },
@@ -178,19 +182,23 @@ public final class AuthorityBottomSheetVC: BaseViewController {
             action: { [weak self] in
                 if isOn {
                     self?.viewModel.blackList(user: data) { [weak self] in
-                        guard let self = self else { return }
-                        if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
-                            self.userData = updated
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self else { return }
+                            if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
+                                self.userData = updated
+                            }
+                            self.studentManagementVC.userList = self.viewModel.userListDatas
                         }
-                        self.studentManagementVC.userList = self.viewModel.userListDatas
                     }
                 } else {
                     self?.viewModel.cancelBlackList(user: data) { [weak self] in
-                        guard let self = self else { return }
-                        if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
-                            self.userData = updated
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self else { return }
+                            if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
+                                self.userData = updated
+                            }
+                            self.studentManagementVC.userList = self.viewModel.userListDatas
                         }
-                        self.studentManagementVC.userList = self.viewModel.userListDatas
                     }
                 }
             },
@@ -204,7 +212,6 @@ public final class AuthorityBottomSheetVC: BaseViewController {
         guard let data = userData else { return }
 
         viewModel.changeAuthority(user: data) { [weak self] in
-            guard let self = self else { return }
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 self.studentManagementVC.userList = self.viewModel.userListDatas

--- a/Projects/Feature/Sources/StudentManagement/BottomSheet/AuthorityBottomSheetVC.swift
+++ b/Projects/Feature/Sources/StudentManagement/BottomSheet/AuthorityBottomSheetVC.swift
@@ -98,6 +98,8 @@ public final class AuthorityBottomSheetVC: BaseViewController {
         blackListSwitch.isOn = data.isBlackList
         adminSwitch.isOn = (data.authority == "ROLE_STUDENT_COUNCIL")
 
+        blackListSwitch.isEnabled = !data.isOuting
+
         forceOutingContainer.isHidden = data.authority == "ROLE_STUDENT_COUNCIL" || data.isBlackList
         blackListContainer.isHidden = data.authority == "ROLE_STUDENT_COUNCIL"
         
@@ -140,11 +142,17 @@ public final class AuthorityBottomSheetVC: BaseViewController {
                 if isOn {
                     self?.viewModel.forceOutingStudent(user: data) { [weak self] in
                         guard let self = self else { return }
+                        if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
+                            self.userData = updated
+                        }
                         self.studentManagementVC.userList = self.viewModel.userListDatas
                     }
                 } else {
                     self?.viewModel.deleteOutingStudent(user: data) { [weak self] in
                         guard let self = self else { return }
+                        if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
+                            self.userData = updated
+                        }
                         self.studentManagementVC.userList = self.viewModel.userListDatas
                     }
                 }
@@ -171,11 +179,17 @@ public final class AuthorityBottomSheetVC: BaseViewController {
                 if isOn {
                     self?.viewModel.blackList(user: data) { [weak self] in
                         guard let self = self else { return }
+                        if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
+                            self.userData = updated
+                        }
                         self.studentManagementVC.userList = self.viewModel.userListDatas
                     }
                 } else {
                     self?.viewModel.cancelBlackList(user: data) { [weak self] in
                         guard let self = self else { return }
+                        if let updated = self.viewModel.userListDatas.first(where: { $0.id == data.id }) {
+                            self.userData = updated
+                        }
                         self.studentManagementVC.userList = self.viewModel.userListDatas
                     }
                 }


### PR DESCRIPTION
# 🍎 개요
- 학생 관리 바텀시트에서 권한 변경 시 데이터가 즉시 동기화되지 않던 문제와 외출 상태일때 외출금지가 되지않게 반영하였습니다.

# 📦 작업 내용
- UserData를 api 성공 후 viewModel.userListDatas에서 최신 객체를 찾아 self.userData를 교체하는 방식으로 변경
-  유저가 현재 외출 상태일 경우 외출 금지 설정을 할 수 없도록 스위치 조작 시 방어 로직 추가

