### PR TITLE
🔀 :: #189 추천(하트) optimistic update 적용 및 bottomSheet 중복 노출 문제 해결

### DIFF
--- a/Projects/Feature/Sources/Scene/Map/View/MapViewController.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapViewController.swift
@@ -298,9 +298,16 @@ private func setupActions() {
     }
     bottomSheetView.onHeartTapped = { [weak self] placeId, isSelected in
         guard let self = self else { return }
+
+    
+        self.updateBottomSheet()
+
+       
         self.viewModel.toggleRecommend(placeId: placeId, isSelected: isSelected) {
+            
             self.viewModel.fetchHotPlaces()
             self.viewModel.fetchRecommendedPlaces()
+            self.viewModel.fetchMyReviews()
         }
     }
 
@@ -374,11 +381,14 @@ private func setupActions() {
                     )
                 }
 
+              
                 self.updateBottomSheet()
             }
 
+       
             self.viewModel.fetchHotPlaces()
             self.viewModel.fetchRecommendedPlaces()
+            self.viewModel.fetchMyReviews()
         }
     }
     routeSelectionView.onCardTapped = { [weak self] routeTitle in

--- a/Projects/Feature/Sources/Scene/Map/View/MapViewController.swift
+++ b/Projects/Feature/Sources/Scene/Map/View/MapViewController.swift
@@ -151,7 +151,6 @@ public override func viewWillAppear(_ animated: Bool) {
         viewModel.fetchRecommendedPlaces()
     }
 
-    
     if viewModel.lastSearchKeyword.isEmpty {
         searchBar.updateState(.home)
         searchBar.textField.text = ""
@@ -160,7 +159,6 @@ public override func viewWillAppear(_ animated: Bool) {
         searchBar.textField.text = viewModel.lastSearchKeyword
     }
 
-    
     if isSearching {
         recentSearchView.isHidden = false
         bottomSheetView.isHidden = true
@@ -188,6 +186,25 @@ public override func viewWillAppear(_ animated: Bool) {
         bottomSheetView.isHidden = false
         placeDetailView.isHidden = true
     }
+
+
+    if selectedPlaceId != -1 {
+       
+        self.placeDetailView.isHidden = false
+        self.bottomSheetView.isHidden = true
+
+        self.bottomSheetHeight?.update(offset: 0)
+        self.detailSheetHeight?.update(offset: self.detailMinHeight)
+    } else {
+      
+        self.placeDetailView.isHidden = true
+        self.bottomSheetView.isHidden = false
+
+        self.bottomSheetHeight?.update(offset: self.defaultHeight)
+        self.detailSheetHeight?.update(offset: 0)
+    }
+
+    self.view.layoutIfNeeded()
 
     DispatchQueue.main.async {
         self.isRestoringState = false
@@ -570,11 +587,20 @@ private func fetchReviews(placeId: Int) {
     vc.onReviewCreated = { [weak self] in
         guard let self = self else { return }
 
-        
         self.fetchReviews(placeId: detailData.placeId)
         self.viewModel.fetchPlaceDetail(placeId: detailData.placeId)
         self.viewModel.fetchHotPlaces()
         self.viewModel.fetchRecommendedPlaces()
+       
+        self.selectedPlaceId = detailData.placeId
+
+        self.bottomSheetView.isHidden = true
+        self.placeDetailView.isHidden = false
+
+        self.bottomSheetHeight?.update(offset: 0)
+        self.detailSheetHeight?.update(offset: self.detailMinHeight)
+
+        self.view.layoutIfNeeded()
     }
 
     self.navigationController?.pushViewController(vc, animated: true)


### PR DESCRIPTION

# 🍎 개요
추천(하트) 기능의 UX를 개선하기 위해 optimistic update를 적용하고,
상세 화면 복귀 시 발생하던 bottomSheet 중복 노출 문제를 함께 해결했습니다.

# 📦 작업 내용
* 하트 클릭 시 UI 즉시 반영 (optimistic update)
* bottomSheet / detailView 상태 동기화 개선
* 서버 응답 이후 데이터 재동기화 추가
    * fetchHotPlaces()
    * fetchRecommendedPlaces()
    * fetchMyReviews()

* 상세 화면 → 복귀 시 bottomSheet가 중복 노출되던 문제 해결
* 뷰 상태 전환 로직 정리