### PR TITLE
🐛 - fix :: 지각자 명단 조회 시 당일 날짜 미반영 및 계산 오류 수정

### DIFF
--- a/Projects/Feature/Sources/Scene/Late/ViewModel/LetecomerViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Late/ViewModel/LetecomerViewModel.swift
@@ -24,6 +24,7 @@ public final class LetecomerViewModel: BaseViewModel {
     
     var date: String = {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         
         return formatter.string(from: Date())

--- a/Projects/Feature/Sources/Scene/Late/ViewModel/LetecomerViewModel.swift
+++ b/Projects/Feature/Sources/Scene/Late/ViewModel/LetecomerViewModel.swift
@@ -23,13 +23,10 @@ public final class LetecomerViewModel: BaseViewModel {
     private let studentCouncilProvider = MoyaProvider<StudentCouncilServices>()
     
     var date: String = {
-        let currentDate = Date()
-        let lastWednesday = currentDate.lastWednesday()
-        
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         
-        return formatter.string(from: lastWednesday)
+        return formatter.string(from: Date())
     }()
     
     var latecomerList: [LatecomerListResponse] = []


### PR DESCRIPTION
# 🍎 개요
- 지각자 명단 조회 시  날짜 계산 오류를 수정했습니다.

# 📦 작업 내용
- LetecomerViewModel 내 기존  고정 날짜(`lastWednesday()`) 로직 제거
- 앱 진입 시점의 당일 날짜(`Date()`)를 기준으로 API를 호출하도록 변경

🔀 :: #196 